### PR TITLE
3 shared ptrを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode/
+
 # Prerequisites
 *.d
 

--- a/toolbox/include/Shared.hpp
+++ b/toolbox/include/Shared.hpp
@@ -27,17 +27,18 @@ class SharedPtr {
 
     SharedPtr& operator=(const SharedPtr& other) {
         if (this != &other) {
+			int *tmp_count = other._count;
+			if (_ptr != NULL) {
+				++(*tmp_count);
+			} else {
+				tmp_count = new int(0);
+			}
             if (--(*_count) <= 0) {
                 delete _ptr;
                 delete _count;
             }
             _ptr = other._ptr;
-            _count = other._count;
-            if (_ptr != NULL) {
-                ++(*_count);
-            } else {
-                _count = new int(0);
-            }
+			_count = tmp_count;
         }
         return *this;
     }

--- a/toolbox/include/Shared.hpp
+++ b/toolbox/include/Shared.hpp
@@ -1,0 +1,104 @@
+// Description: This file is a mimic of SharedPtr in C++11.
+// std::SharedPtr cannot be used in C++98, so I mimic it.
+
+#pragma once
+
+#include <algorithm>
+
+namespace toolbox {
+template <typename T>
+class SharedPtr {
+ public:
+    SharedPtr() : _ptr(NULL), _count(new int(0)) {}
+
+    explicit SharedPtr(T* ptr) : _ptr(ptr), _count(new int(1)) {
+        if (ptr == NULL) {
+            *_count = 0;
+        }
+    }
+    SharedPtr(const SharedPtr& other)
+        : _ptr(other._ptr), _count(other._count) {
+        if (_ptr != NULL) {
+            ++(*_count);
+        } else {
+            _count = new int(0);
+        }
+    }
+
+    SharedPtr& operator=(const SharedPtr& other) {
+        if (this != &other) {
+            if (--(*_count) <= 0) {
+                delete _ptr;
+                delete _count;
+            }
+            _ptr = other._ptr;
+            _count = other._count;
+            if (_ptr != NULL) {
+                ++(*_count);
+            } else {
+                _count = new int(0);
+            }
+        }
+        return *this;
+    }
+
+    void swap(SharedPtr& other) {
+        std::swap(_ptr, other._ptr);
+        std::swap(_count, other._count);
+    }
+
+    ~SharedPtr() {
+        if (*_count == 0) {
+            delete _count;
+            return;
+        }
+        if (--(*_count) == 0) {
+            delete _ptr;
+            delete _count;
+        }
+    }
+
+    T* const get() const {
+        return _ptr;
+    }
+
+    int use_count() const {
+        return *_count;
+    }
+
+    void reset(T* ptr = NULL) {
+        int* new_count = new int(1);
+        if (ptr == NULL) {
+            *new_count = 0;
+        }
+        if (--(*_count) == 0) {
+            delete _ptr;
+            delete _count;
+        }
+        _ptr = ptr;
+        _count = new_count;
+    }
+
+    T& operator*() const {
+        return *_ptr;
+    }
+
+    T* operator->() const {
+        return _ptr;
+    }
+
+    explicit operator bool() const {
+        return _ptr != NULL;
+    }
+
+ private:
+    T* _ptr;
+    int* _count;
+};
+
+template <typename T>
+void swap(SharedPtr<T>& lhs, SharedPtr<T>& rhs) {
+    lhs.swap(rhs);
+}
+
+}  // namespace toolbox


### PR DESCRIPTION
## 概要

## 変更内容

* std::shared_ptrと同等の機能を持つtoolbox::SharedPtrを追加した
* gitignoreに、vscodeの設定ファイルを追加した

## 関連Issue

* #3 

## 影響範囲

* ぜんぶ

## テスト

* #3 を参照

## その他

* 特になし
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Chore | .vscodeディレクトリを.gitignoreに追加し、VSCodeの設定ファイルをバージョン管理から除外しました。 |
| New Feature | C++98で使用可能な`toolbox::SharedPtr`クラスを追加し、C++11の`std::shared_ptr`と同等の機能を提供します。 |

このプルリクエストでは、開発環境の整備とメモリ管理の向上が図られており、特にC++98環境での互換性を考慮した新機能の追加が素晴らしいです。コードの保守性と拡張性が高まっています。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->