### PR TITLE
perf: listen関数の第二引数の修正

### DIFF
--- a/src/socket/server.cpp
+++ b/src/socket/server.cpp
@@ -62,7 +62,7 @@ void Server::createServerSocket() {
         exit(EXIT_FAILURE);
     }
 
-    if (listen(_server_sock, 5) == -1) {
+    if (listen(_server_sock, SOMAXCONN) == -1) {
         perror("listen");
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
~

## 概要
listen関数の第二引数の値を変更することで、同時接続を増やすと動作が遅い問題について #10を解消した。
## 変更内容

* src/soket/server.cppのlisten関数の第二引数を`SOMAXCONN`に変更した。
>第二引数は、 sockfd についての保留中の接続のキューの最大長を指定する。 キューがいっぱいの状態で接続要求が到着すると、クライアントは ECONNREFUSED というエラーを受け取る。
client側(ab command)での内部的な処理は判らないが、server側のacceptキューが小さかったため多数のクライアントからの接続要求を処理できなかったのではないかと考えられる。
man listenを参照

## 関連Issue

* #10 

## 影響範囲

* src/soket/server.cpp

## テスト

* `ab -n 10000 -c 128 http://127.0.0.1:5000/`
自分の環境で上記のテストを実行すると平均して3秒に収まった。 

## その他

* 