### PR TITLE
avoid using array designator in StepMark class

### DIFF
--- a/toolbox/stepmark.cpp
+++ b/toolbox/stepmark.cpp
@@ -44,11 +44,11 @@ logger::StepMark& logger::StepMark::getInstance() {
 
 void logger::StepMark::log(StepmarkLevel level, const std::string& message) {
     const char* levelStr[] = {
-        [DEBUG] = "DEBUG",
-        [INFO] = "INFO",
-        [WARNING] = "WARNING",
-        [ERROR] = "ERROR",
-        [CRITICAL] = "CRITICAL"
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL"
     };
 
     logger::StepMark& instance = getInstance();


### PR DESCRIPTION
## 概要

array designatorを使うのを避ける

## 変更内容

* array designatorはC99の機能であるため、C++98では使えない。これを避ける

## 関連Issue

* #52

## 影響範囲

* StepMarkクラス（挙動は変わっていない）

## テスト

* 校舎に行ける方が校舎PCでC++98でコンパイルできるかどうかを確かめていただけると助かります。

## その他

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | `StepMark`クラスの`log`関数内で、C99配列指定子を使用せずに`levelStr`配列を初期化するように変更しました。これにより、C++98標準との互換性が向上しました。 |

このプルリクエストでは、コードの互換性を保ちながらも、標準に準拠した方法での実装に改善されており、将来的なメンテナンス性が向上しています。特に、外部インターフェースや動作を変えずに内部の実装を改善した点が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->