### PR TITLE
59 cgiresponseparserクラスの作成

### DIFF
--- a/src/http/cgi/cgi_field_parser.cpp
+++ b/src/http/cgi/cgi_field_parser.cpp
@@ -1,0 +1,25 @@
+#include <string>
+
+#include "cgi_field_parser.hpp"
+
+namespace http {
+bool CgiFieldParser::isUnique(const std::string& key) {
+    return key == fields::CONTENT_LENGTH ||
+        key == fields::TRANSFER_ENCODING ||
+        key == fields::CONTENT_TYPE ||
+        key == fields::LOCATION;
+}
+
+void CgiFieldParser::handleInvalidFieldError
+(const std::string& key, HttpStatus& hs) {
+    toolbox::logger::StepMark::info("RequestFieldParser: invalid " + key);
+    hs.set(HttpStatus::INTERNAL_SERVER_ERROR);
+}
+
+void CgiFieldParser::handleDuplicateFieldError
+(const std::string& key, HttpStatus& hs) {
+    toolbox::logger::StepMark::info("RequestFieldParser: duplicate " + key);
+    hs.set(HttpStatus::INTERNAL_SERVER_ERROR);
+}
+
+}  // namespace http

--- a/src/http/cgi/cgi_field_parser.hpp
+++ b/src/http/cgi/cgi_field_parser.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+
+#include "../parsing/base_field_parser.hpp"
+#include "../http_namespace.hpp"
+
+namespace http {
+class CgiFieldParser : public BaseFieldParser {
+ public:
+    CgiFieldParser() {}
+    ~CgiFieldParser() {}
+
+ private:
+    bool isUnique(const std::string& key);
+    void handleInvalidFieldError(const std::string& key, HttpStatus& hs);
+    void handleDuplicateFieldError(const std::string& key, HttpStatus& hs);
+};
+
+}  // namespace http

--- a/src/http/cgi/cgi_response.cpp
+++ b/src/http/cgi/cgi_response.cpp
@@ -1,0 +1,59 @@
+#include <string>
+#include <iostream>
+
+#include "cgi_response.hpp"
+
+namespace http {
+static bool isLocalURI(const std::string& path) {
+    return (path.size() >= 2 && path[0] == '/' && path[1] != '/');
+}
+
+static bool isAbsoluteURI(const std::string& path) {
+    return path.find("://") != std::string::npos;
+}
+
+static bool isClientRedirectStatus(http::HttpStatus::EHttpStatus status) {
+    return (status == HttpStatus::MOVED_PERMANENTLY ||
+            status == HttpStatus::FOUND ||
+            status == HttpStatus::SEE_OTHER ||
+            status == HttpStatus::TEMPORARY_REDIRECT ||
+            status == HttpStatus::PERMANENT_REDIRECT);
+}
+
+void CgiResponse::identifyCgiType() {
+    if (httpStatus.get() == HttpStatus::INTERNAL_SERVER_ERROR) {
+        return;
+    }
+    HTTPFields::FieldValue location = fields.getFieldValue(fields::LOCATION);
+    bool emptyContentType = fields.getFieldValue(fields::CONTENT_TYPE).empty();
+    bool isStatusUnset = httpStatus.get() == HttpStatus::UNSET;
+    if (location.empty()) {
+        if (!emptyContentType) {
+            cgiType = DOCUMENT;
+            if (isStatusUnset) {
+                httpStatus.set(HttpStatus::OK);
+            }
+        }
+        return;
+    }
+    bool isOnlyLocation = fields.countNonEmptyValues() == 1;
+    bool hasEmptyBody = body.empty();
+    if (isLocalURI(location[0]) && isOnlyLocation &&
+        hasEmptyBody && isStatusUnset) {
+        cgiType = LOCAL_REDIRECT;
+        return;
+    }
+    if (!isAbsoluteURI(location[0])) {
+        return;
+    }
+    if (isOnlyLocation && isStatusUnset) {
+        cgiType = CLIENT_REDIRECT;
+        return;
+    }
+    if (!emptyContentType && !hasEmptyBody &&
+        isClientRedirectStatus(httpStatus.get())) {
+        cgiType = CLIENT_REDIRECT_DOCUMENT;
+    }
+}
+
+}  // namespace http

--- a/src/http/cgi/cgi_response.cpp
+++ b/src/http/cgi/cgi_response.cpp
@@ -5,7 +5,13 @@
 
 namespace http {
 static bool isLocalURI(const std::string& path) {
-    return (path.size() >= 2 && path[0] == '/' && path[1] != '/');
+    if (!path.empty() && path[0] != *symbols::SLASH) {
+        return false;
+    }
+    if (path.size() >= 2 && path[1] == *symbols::SLASH) {
+        return false;
+    }
+    return true;
 }
 
 static bool isAbsoluteURI(const std::string& path) {

--- a/src/http/cgi/cgi_response.hpp
+++ b/src/http/cgi/cgi_response.hpp
@@ -8,15 +8,26 @@
 namespace http {
 class CgiResponse {
  public:
-    inline CgiResponse() {
-        httpStatus.set(HttpStatus::OK);
+    enum CgiType {
+        DOCUMENT = 0,
+        LOCAL_REDIRECT = 1,
+        CLIENT_REDIRECT = 2,
+        CLIENT_REDIRECT_DOCUMENT = 3,
+        INVALID = 4
+    };
+
+    inline CgiResponse() : cgiType(INVALID) {
+        httpStatus.set(HttpStatus::UNSET);
         fields.initFieldsMap();
     }
     ~CgiResponse() {}
 
+    void identifyCgiType();
+
     HttpStatus httpStatus;
     HTTPFields fields;
     std::string body;
+    CgiType cgiType;
 
  private:
     CgiResponse(const CgiResponse& other);

--- a/src/http/cgi/cgi_response.hpp
+++ b/src/http/cgi/cgi_response.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+#include "../request/http_fields.hpp"
+#include "../http_status.hpp"
+
+namespace http {
+class CgiResponse {
+ public:
+    CgiResponse() { httpStatus.set(HttpStatus::EHttpStatus::UNSET); }
+    ~CgiResponse() {}
+
+    HttpStatus httpStatus;
+    HTTPFields fields;
+    std::string body;
+
+ private:
+    CgiResponse(const CgiResponse& other);
+    CgiResponse& operator=(const CgiResponse& other);
+};
+
+}  // namespace http

--- a/src/http/cgi/cgi_response.hpp
+++ b/src/http/cgi/cgi_response.hpp
@@ -9,7 +9,7 @@ namespace http {
 class CgiResponse {
  public:
     inline CgiResponse() {
-        httpStatus.set(HttpStatus::EHttpStatus::UNSET);
+        httpStatus.set(HttpStatus::OK);
         fields.initFieldsMap();
     }
     ~CgiResponse() {}

--- a/src/http/cgi/cgi_response.hpp
+++ b/src/http/cgi/cgi_response.hpp
@@ -18,7 +18,6 @@ class CgiResponse {
 
     inline CgiResponse() : cgiType(INVALID) {
         httpStatus.set(HttpStatus::UNSET);
-        fields.initFieldsMap();
     }
     ~CgiResponse() {}
 

--- a/src/http/cgi/cgi_response.hpp
+++ b/src/http/cgi/cgi_response.hpp
@@ -8,7 +8,10 @@
 namespace http {
 class CgiResponse {
  public:
-    CgiResponse() { httpStatus.set(HttpStatus::EHttpStatus::UNSET); }
+    inline CgiResponse() {
+        httpStatus.set(HttpStatus::EHttpStatus::UNSET);
+        fields.initFieldsMap();
+    }
     ~CgiResponse() {}
 
     HttpStatus httpStatus;

--- a/src/http/cgi/cgi_response_parser.cpp
+++ b/src/http/cgi/cgi_response_parser.cpp
@@ -13,7 +13,7 @@ BaseParser::ParseStatus CgiResponseParser::processFieldLine() {
             return P_NEED_MORE_DATA;
         }
         if (lineEnd.pos == 0) {
-            return handleFieldEnd();
+            return handleFieldEnd(lineEnd.len);
         }
         std::string line = getBuf()->substr(0, lineEnd.pos);
         setBuf(getBuf()->substr(lineEnd.pos + lineEnd.len));
@@ -29,13 +29,14 @@ BaseParser::ParseStatus CgiResponseParser::processBody() {
     return P_NEED_MORE_DATA;
 }
 
-BaseParser::ParseStatus CgiResponseParser::handleFieldEnd() {
+BaseParser::ParseStatus CgiResponseParser::handleFieldEnd(
+    const std::size_t lineEndLen) {
     if (!FieldValidator::validateCgiHeaders(_response.fields,
                                             _response.httpStatus)) {
         throw ParseException("");
     }
     setValidatePos(V_BODY);
-    setBuf(getBuf()->substr(2));  // Skip CRLF
+    setBuf(getBuf()->substr(lineEndLen));
     return P_IN_PROGRESS;
 }
 

--- a/src/http/cgi/cgi_response_parser.cpp
+++ b/src/http/cgi/cgi_response_parser.cpp
@@ -22,12 +22,13 @@ BaseParser::ParseStatus CgiResponseParser::processFieldLine() {
         if (lineEndPos == 0) {
             setValidatePos(V_BODY);
             setBuf(getBuf()->substr(lineEndLen));
-            return;
+            return P_IN_PROGRESS;
         }
         std::string line = getBuf()->substr(0, lineEndPos);
         setBuf(getBuf()->substr(lineEndPos + lineEndLen));
         if (!FieldValidator::validateFieldLine(line)) {
-            break;
+            _response.httpStatus.set(HttpStatus::BAD_REQUEST);
+            continue;
         }
         HTTPFields::FieldPair pair = BaseFieldParser::splitFieldLine(&line);
         if (pair.second.empty()) {
@@ -44,6 +45,10 @@ BaseParser::ParseStatus CgiResponseParser::processFieldLine() {
         lfPos = getBuf()->find(symbols::LF);
     }
     return P_NEED_MORE_DATA;
+}
+
+BaseParser::ParseStatus CgiResponseParser::processBody() {
+    return BaseParser::P_ERROR;
 }
 
 }  // namespace http

--- a/src/http/cgi/cgi_response_parser.cpp
+++ b/src/http/cgi/cgi_response_parser.cpp
@@ -1,0 +1,49 @@
+#include <string>
+
+#include "cgi_response_parser.hpp"
+
+namespace http {
+BaseParser::ParseStatus CgiResponseParser::processFieldLine() {
+    if (getBuf()->find(symbols::CRLF) == std::string::npos) {
+        return P_NEED_MORE_DATA;
+    }
+    std::size_t crlfPos = getBuf()->find(symbols::CRLF);
+    std::size_t lfPos = getBuf()->find(symbols::LF);
+    while (crlfPos != std::string::npos || lfPos != std::string::npos) {
+        std::size_t lineEndPos;
+        std::size_t lineEndLen;
+        if (crlfPos < lfPos) {
+            lineEndPos = crlfPos;
+            lineEndLen = 2;  // symbolx::CRLF.size()
+        } else {
+            lineEndPos = lfPos;
+            lineEndLen = 1;  // symbols::LF.size()
+        }
+        if (lineEndPos == 0) {
+            setValidatePos(V_BODY);
+            setBuf(getBuf()->substr(lineEndLen));
+            return;
+        }
+        std::string line = getBuf()->substr(0, lineEndPos);
+        setBuf(getBuf()->substr(lineEndPos + lineEndLen));
+        if (!FieldValidator::validateFieldLine(line)) {
+            break;
+        }
+        HTTPFields::FieldPair pair = BaseFieldParser::splitFieldLine(&line);
+        if (pair.second.empty()) {
+            continue;
+        }
+        if (utils::isEqualCaseInsensitive(pair.first, "status") &&
+            _response.httpStatus.get() == HttpStatus::UNSET) {
+                _response.httpStatus.set(std::atoi(pair.second[0].c_str()));
+        } else {
+            _fieldParser.parseFieldLine(pair, _response.fields.get(),
+                _response.httpStatus);
+        }
+        crlfPos = getBuf()->find(symbols::CRLF);
+        lfPos = getBuf()->find(symbols::LF);
+    }
+    return P_NEED_MORE_DATA;
+}
+
+}  // namespace http

--- a/src/http/cgi/cgi_response_parser.hpp
+++ b/src/http/cgi/cgi_response_parser.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include <cstdlib>
 
 #include "../parsing/base_field_parser.hpp"
@@ -12,6 +14,11 @@
 namespace http {
 class CgiResponseParser : public BaseParser {
  public:
+    struct LineEndInfo {
+        LineEndInfo(std::size_t pos, std::size_t len) : pos(pos), len(len) {}
+        std::size_t pos;
+        std::size_t len;
+    };
     inline CgiResponseParser() { setValidatePos(V_FIELD); }
     ~CgiResponseParser() {}
 
@@ -21,6 +28,9 @@ class CgiResponseParser : public BaseParser {
     ParseStatus processRequestLine() { return BaseParser::P_ERROR; }
     ParseStatus processFieldLine();
     ParseStatus processBody();
+    bool processFieldLineContent(std::string& line);
+    LineEndInfo findLineEnd();
+    BaseParser::ParseStatus handleFieldEnd();
     bool parseStatus(HTTPFields::FieldPair& pair);
 
     CgiResponse _response;

--- a/src/http/cgi/cgi_response_parser.hpp
+++ b/src/http/cgi/cgi_response_parser.hpp
@@ -31,7 +31,7 @@ class CgiResponseParser : public BaseParser {
     ParseStatus processBody();
     bool processFieldLineContent(std::string& line);
     LineEndInfo findLineEnd();
-    BaseParser::ParseStatus handleFieldEnd();
+    BaseParser::ParseStatus handleFieldEnd(const std::size_t lineEndLen);
     bool parseStatus(HTTPFields::FieldPair& pair);
     bool isValidStatusMessage(int code, const std::string& message);
 

--- a/src/http/cgi/cgi_response_parser.hpp
+++ b/src/http/cgi/cgi_response_parser.hpp
@@ -21,6 +21,7 @@ class CgiResponseParser : public BaseParser {
     ParseStatus processRequestLine() { return BaseParser::P_ERROR; }
     ParseStatus processFieldLine();
     ParseStatus processBody();
+    bool parseStatus(HTTPFields::FieldPair& pair);
 
     CgiResponse _response;
     CgiFieldParser _fieldParser;

--- a/src/http/cgi/cgi_response_parser.hpp
+++ b/src/http/cgi/cgi_response_parser.hpp
@@ -7,6 +7,7 @@
 #include "../parsing/base_field_parser.hpp"
 #include "../parsing/field_validator.hpp"
 #include "../parsing/base_parser.hpp"
+#include "../response/response.hpp"
 #include "../string_utils.hpp"
 #include "cgi_field_parser.hpp"
 #include "cgi_response.hpp"
@@ -32,6 +33,7 @@ class CgiResponseParser : public BaseParser {
     LineEndInfo findLineEnd();
     BaseParser::ParseStatus handleFieldEnd();
     bool parseStatus(HTTPFields::FieldPair& pair);
+    bool isValidStatusMessage(int code, const std::string& message);
 
     CgiResponse _response;
     CgiFieldParser _fieldParser;

--- a/src/http/cgi/cgi_response_parser.hpp
+++ b/src/http/cgi/cgi_response_parser.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdlib>
+
 #include "../parsing/base_field_parser.hpp"
 #include "../parsing/field_validator.hpp"
 #include "../parsing/base_parser.hpp"
@@ -16,6 +18,7 @@ class CgiResponseParser : public BaseParser {
     inline CgiResponse& get() { return _response; }
 
  private:
+    ParseStatus processRequestLine() { return BaseParser::P_ERROR; }
     ParseStatus processFieldLine();
     ParseStatus processBody();
 

--- a/src/http/cgi/cgi_response_parser.hpp
+++ b/src/http/cgi/cgi_response_parser.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../parsing/base_field_parser.hpp"
+#include "../parsing/field_validator.hpp"
+#include "../parsing/base_parser.hpp"
+#include "../string_utils.hpp"
+#include "cgi_field_parser.hpp"
+#include "cgi_response.hpp"
+
+namespace http {
+class CgiResponseParser : public BaseParser {
+ public:
+    inline CgiResponseParser() { setValidatePos(V_FIELD); }
+    ~CgiResponseParser() {}
+
+    inline CgiResponse& get() { return _response; }
+
+ private:
+    ParseStatus processFieldLine();
+    ParseStatus processBody();
+
+    CgiResponse _response;
+    CgiFieldParser _fieldParser;
+};
+
+}  // namespace http

--- a/src/http/http_status.hpp
+++ b/src/http/http_status.hpp
@@ -58,7 +58,7 @@ class HttpStatus {
 
     void set(EHttpStatus status) { _status = status; }
     void set(int status) { _status = static_cast<EHttpStatus>(status); }
-    EHttpStatus get() { return _status; }
+    EHttpStatus get() const { return _status; }
 
  private:
     EHttpStatus _status;

--- a/src/http/http_status.hpp
+++ b/src/http/http_status.hpp
@@ -54,6 +54,7 @@ class HttpStatus {
     };
 
     HttpStatus() : _status(OK) {}
+    explicit HttpStatus(EHttpStatus status) : _status(status) {}
     ~HttpStatus() {}
 
     void set(EHttpStatus status) { _status = status; }

--- a/src/http/http_status.hpp
+++ b/src/http/http_status.hpp
@@ -57,6 +57,7 @@ class HttpStatus {
     ~HttpStatus() {}
 
     void set(EHttpStatus status) { _status = status; }
+    void set(int status) { _status = static_cast<EHttpStatus>(status); }
     EHttpStatus get() { return _status; }
 
  private:

--- a/src/http/parsing/base_field_parser.hpp
+++ b/src/http/parsing/base_field_parser.hpp
@@ -14,8 +14,8 @@ class BaseFieldParser {
     bool parseFieldLine(const HTTPFields::FieldPair& pair,
         HTTPFields::FieldMap& fields, HttpStatus& hs);
     static HTTPFields::FieldPair splitFieldLine(std::string* line);
-    // bool parseCgiFieldLine(const HTTPFields::FieldPair& pair,
-                            // HttpStatus& hs);
+    bool parseCgiFieldLine(const HTTPFields::FieldPair& pair,
+                            HttpStatus& hs);
 
  protected:
     BaseFieldParser(const BaseFieldParser& other);
@@ -24,7 +24,7 @@ class BaseFieldParser {
     bool hostFieldLine(HTTPFields::FieldMap::iterator& target,
                     const HTTPFields::FieldPair& pair,
                     HttpStatus& hs);
-    virtual bool uniqueFieldLine(HTTPFields::FieldMap::iterator& target,
+    bool uniqueFieldLine(HTTPFields::FieldMap::iterator& target,
                     const HTTPFields::FieldPair& pair,
                     HttpStatus& hs);
     void normalFieldLine(HTTPFields::FieldMap::iterator& target,

--- a/src/http/parsing/field_validator.cpp
+++ b/src/http/parsing/field_validator.cpp
@@ -4,7 +4,7 @@
 #include "field_validator.hpp"
 
 namespace http {
-bool FieldValidator::validateFieldLine(std::string& line) {
+bool FieldValidator::validateFieldLine(const std::string& line) {
     if (utils::hasCtlChar(line) || line.size() > fields::MAX_FIELDLINE_SIZE ||
         line.find(symbols::COLON) == std::string::npos) {
         return false;

--- a/src/http/parsing/field_validator.hpp
+++ b/src/http/parsing/field_validator.hpp
@@ -10,23 +10,34 @@
 namespace http {
 class FieldValidator {
  public:
+    struct Result {
+        bool success;
+        HttpStatus::EHttpStatus status;
+
+        explicit Result(bool s = true,
+            HttpStatus::EHttpStatus st = HttpStatus::OK)
+            : success(s), status(st) {}
+        operator bool() const { return success; }
+        bool operator!() const { return !success; }
+    };
+
     FieldValidator() {}
     ~FieldValidator() {}
 
     static bool validateFieldLine(std::string& line);
     static bool validateRequestHeaders(HTTPFields& fields, HttpStatus& hs);
-    // static bool validateResponseHeaders(HTTPFields& fields, HttpStatus& hs);
+    static bool validateCgiHeaders(HTTPFields& fields, HttpStatus& hs);
 
  private:
     FieldValidator(const FieldValidator& other);
     FieldValidator& operator=(const FieldValidator& other);
 
-    static bool validateHostExists(HTTPFields& fields, HttpStatus& hs);
-    static bool validateContentHeaders(HTTPFields& fields, HttpStatus& hs);
-    static bool validateContentLength
-        (HTTPFields::FieldMap::iterator contentLength, HttpStatus& hs);
-    static bool validateTransferEncoding
-        (HTTPFields::FieldMap::iterator transferEncoding, HttpStatus& hs);
+    static Result validateHostExists(HTTPFields& fields);
+    static Result validateContentHeaders(HTTPFields& fields);
+    static Result validateContentLength
+        (HTTPFields::FieldMap::iterator contentLength);
+    static Result validateTransferEncoding
+        (HTTPFields::FieldMap::iterator transferEncoding);
 };
 
 }  // namespace http

--- a/src/http/parsing/field_validator.hpp
+++ b/src/http/parsing/field_validator.hpp
@@ -10,17 +10,6 @@
 namespace http {
 class FieldValidator {
  public:
-    struct Result {
-        bool success;
-        HttpStatus::EHttpStatus status;
-
-        explicit Result(bool s = true,
-            HttpStatus::EHttpStatus st = HttpStatus::OK)
-            : success(s), status(st) {}
-        operator bool() const { return success; }
-        bool operator!() const { return !success; }
-    };
-
     FieldValidator() {}
     ~FieldValidator() {}
 
@@ -32,11 +21,11 @@ class FieldValidator {
     FieldValidator(const FieldValidator& other);
     FieldValidator& operator=(const FieldValidator& other);
 
-    static Result validateHostExists(HTTPFields& fields);
-    static Result validateContentHeaders(HTTPFields& fields);
-    static Result validateContentLength
+    static HttpStatus::EHttpStatus validateHostExists(HTTPFields& fields);
+    static HttpStatus::EHttpStatus validateContentHeaders(HTTPFields& fields);
+    static HttpStatus::EHttpStatus validateContentLength
         (HTTPFields::FieldMap::iterator contentLength);
-    static Result validateTransferEncoding
+    static HttpStatus::EHttpStatus validateTransferEncoding
         (HTTPFields::FieldMap::iterator transferEncoding);
 };
 

--- a/src/http/parsing/field_validator.hpp
+++ b/src/http/parsing/field_validator.hpp
@@ -13,7 +13,7 @@ class FieldValidator {
     FieldValidator() {}
     ~FieldValidator() {}
 
-    static bool validateFieldLine(std::string& line);
+    static bool validateFieldLine(const std::string& line);
     static bool validateRequestHeaders(HTTPFields& fields, HttpStatus& hs);
     static bool validateCgiHeaders(HTTPFields& fields, HttpStatus& hs);
 

--- a/src/http/request/http_fields.cpp
+++ b/src/http/request/http_fields.cpp
@@ -22,7 +22,6 @@ std::size_t HTTPFields::countNonEmptyValues() {
     return count;
 }
 
-
 HTTPFields::FieldValue& HTTPFields::getFieldValue(const std::string& key) {
     static HTTPFields::FieldValue emptyVector;
     if (_fieldsMap.find(key) != _fieldsMap.end()) {

--- a/src/http/request/http_fields.cpp
+++ b/src/http/request/http_fields.cpp
@@ -11,6 +11,18 @@ void HTTPFields::initFieldsMap() {
         }
 }
 
+std::size_t HTTPFields::countNonEmptyValues() {
+    std::size_t count = 0;
+    for (FieldMap::iterator it = _fieldsMap.begin();
+         it != _fieldsMap.end(); ++it) {
+        if (!it->second.empty()) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+
 HTTPFields::FieldValue& HTTPFields::getFieldValue(const std::string& key) {
     static HTTPFields::FieldValue emptyVector;
     if (_fieldsMap.find(key) != _fieldsMap.end()) {

--- a/src/http/request/http_fields.hpp
+++ b/src/http/request/http_fields.hpp
@@ -19,7 +19,7 @@ class HTTPFields {
     typedef std::pair<FieldKey, FieldValue> FieldPair;
     typedef std::map<FieldKey, FieldValue, CaseInsensitiveLess> FieldMap;
 
-    HTTPFields() {}
+    HTTPFields() { initFieldsMap(); }
     ~HTTPFields() {}
 
     void initFieldsMap();

--- a/src/http/request/http_fields.hpp
+++ b/src/http/request/http_fields.hpp
@@ -23,6 +23,7 @@ class HTTPFields {
     ~HTTPFields() {}
 
     void initFieldsMap();
+    std::size_t countNonEmptyValues();
     FieldValue& getFieldValue(const std::string& key);
     FieldMap& get() { return _fieldsMap; }
 

--- a/src/http/request/request_parser.cpp
+++ b/src/http/request/request_parser.cpp
@@ -20,9 +20,6 @@ BaseParser::ParseStatus RequestParser::processFieldLine() {
     if (getBuf()->find(symbols::CRLF) == std::string::npos) {
         return P_NEED_MORE_DATA;
     }
-    if (_request.fields.get().empty()) {
-        _request.fields.initFieldsMap();
-    }
     while (getBuf()->find(symbols::CRLF) != std::string::npos) {
         if (getBuf()->find(symbols::CRLF) == 0) {
             if (!FieldValidator::validateRequestHeaders

--- a/src/http/request/request_parser.cpp
+++ b/src/http/request/request_parser.cpp
@@ -25,6 +25,10 @@ BaseParser::ParseStatus RequestParser::processFieldLine() {
     }
     while (getBuf()->find(symbols::CRLF) != std::string::npos) {
         if (getBuf()->find(symbols::CRLF) == 0) {
+            if (!FieldValidator::validateRequestHeaders
+                (_request.fields, _request.httpStatus)) {
+                throw ParseException("");
+            }
             setValidatePos(V_BODY);
             setBuf(getBuf()->substr(sizeof(*symbols::CRLF)));
             break;
@@ -40,11 +44,6 @@ BaseParser::ParseStatus RequestParser::processFieldLine() {
             throw ParseException("");
         }
     }
-    if (!FieldValidator::validateRequestHeaders(_request.fields,
-                                                _request.httpStatus)) {
-        throw ParseException("");
-    }
-    setValidatePos(V_BODY);
     return P_IN_PROGRESS;
 }
 

--- a/src/http/request/request_parser.cpp
+++ b/src/http/request/request_parser.cpp
@@ -127,19 +127,9 @@ void RequestParser::validateMethod() {
         _request.httpStatus.set(HttpStatus::BAD_REQUEST);
         return;
     }
-    if (_request.version == uri::HTTP_VERSION_1_0) {
-        if (_request.method != method::GET &&
-            _request.method != method::HEAD &&
-            _request.method != method::POST) {
-            _request.httpStatus.set(HttpStatus::BAD_REQUEST);
-        }
-    } else {
-        if (_request.method != method::GET &&
-            _request.method != method::HEAD &&
-            _request.method != method::POST &&
-            _request.method != method::DELETE) {
-            _request.httpStatus.set(HttpStatus::BAD_REQUEST);
-        }
+    if (!utils::isUpperStr(_request.method)) {
+        _request.httpStatus.set(HttpStatus::BAD_REQUEST);
+        return;
     }
 }
 
@@ -179,16 +169,6 @@ void RequestParser::validatePath() {
         _request.httpStatus.set(HttpStatus::URI_TOO_LONG);
         toolbox::logger::StepMark::info(
             "RequestParser: uri too large");
-
-        return;
-    }
-    if (_request.uri.fullUri[0] != *symbols::SLASH ||
-        utils::hasCtlChar(_request.uri.fullUri)) {
-        _request.httpStatus.set(HttpStatus::BAD_REQUEST);
-        toolbox::logger::StepMark::info(
-            "RequestParser: invalid uri");
-
-        return;
     }
 }
 
@@ -229,10 +209,7 @@ void RequestParser::percentDecode(std::string& line) {
             ++i;
         }
     }
-    if (!utils::hasCtlChar(res)) {
-        line = res;
-    }
-    return;
+    line = res;
 }
 
 bool RequestParser::decodeHex(std::string& hexStr, std::string& decodedStr) {

--- a/src/http/response/response.cpp
+++ b/src/http/response/response.cpp
@@ -93,7 +93,7 @@ std::string Response::buildResponse() const {
     return oss.str();
 }
 
-std::string Response::getStatusMessage(int code) const {
+std::string Response::getStatusMessage(int code) {
     switch (code) {
         case 200: return "OK";
         case 201: return "Created";

--- a/src/http/response/response.hpp
+++ b/src/http/response/response.hpp
@@ -33,13 +33,13 @@ class Response {
     void setBody(const std::string& body);
 
     void sendResponse(int client_fd) const;
+    static std::string getStatusMessage(int code);
 
  private:
     int _status;
     std::map<FieldName, HeaderField> _headers;
     std::string _body;
 
-    std::string getStatusMessage(int code) const;
     std::string buildResponse() const;
 };
 

--- a/src/http/string_utils.cpp
+++ b/src/http/string_utils.cpp
@@ -14,6 +14,11 @@ bool hasCtlChar(const std::string& str) {
     return toolbox::any_true(str.begin(), str.end(), isCntrl);
 }
 
+bool isUpperStr(const std::string& str) {
+    int (*isUpper)(int) = std::isupper;
+    return toolbox::all_true(str.begin(), str.end(), isUpper);
+}
+
 bool isDigitStr(const std::string& str) {
     int (*isDigit)(int) = std::isdigit;
     return toolbox::all_true(str.begin(), str.end(), isDigit);

--- a/src/http/string_utils.hpp
+++ b/src/http/string_utils.hpp
@@ -9,6 +9,7 @@ namespace http {
 namespace utils {
 bool hasWhiteSpace(const std::string& str);
 bool hasCtlChar(const std::string& str);
+bool isUpperStr(const std::string& str);
 bool isDigitStr(const std::string& str);
 bool isAlnumStr(const std::string& str);
 void trimSpace(std::string* str);

--- a/test/http/cgi/Makefile
+++ b/test/http/cgi/Makefile
@@ -1,0 +1,35 @@
+NAME = test.out
+
+SRC_DIRS = ../../../src
+TOOLBOX_DIR = ../../../toolbox
+
+TEST_SRCS = $(filter-out $(SRC_DIRS)/core/main.cpp, $(wildcard $(SRC_DIRS)/*/*.cpp)\
+			$(wildcard $(SRC_DIRS)/*/*/*.cpp) $(wildcard $(TOOLBOX_DIR)/*.cpp))\
+			$(wildcard *.cpp) \
+            $(wildcard http/*.cpp) \
+            $(wildcard http/request/*.cpp) \
+			$(wildcard http/cgi/*.cpp)\
+
+CXX = c++
+CXXFLAGS = -Wall -Wextra -Werror -std=c++98 -I..
+
+TEST_OBJS = $(TEST_SRCS:.cpp=.o)
+
+all: $(NAME)
+
+$(NAME): $(TEST_OBJS)
+	$(CXX) $(CXXFLAGS) -o $(NAME) $(TEST_OBJS)
+
+clean:
+	$(RM) $(TEST_OBJS)
+
+fclean: clean
+	$(RM) $(NAME)
+	$(RM) cgi_test.log
+
+re: fclean all
+
+run: all
+	./$(NAME)
+
+.PHONY: all clean fclean re run

--- a/test/http/cgi/Makefile
+++ b/test/http/cgi/Makefile
@@ -1,4 +1,4 @@
-NAME = test.out
+NAME = cgi_test.out
 
 SRC_DIRS = ../../../src
 TOOLBOX_DIR = ../../../toolbox

--- a/test/http/cgi/cgi_response_test.hpp
+++ b/test/http/cgi/cgi_response_test.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+#include "../../../src/http/request/http_fields.hpp"
+#include "../../../src/http/http_status.hpp"
+
+class CgiResponseTest {
+ public:
+    std::string name;
+    std::string request;
+    bool isSuccessTest;
+    http::HttpStatus httpStatus;
+    http::HTTPFields::FieldMap exceptMap;
+    std::string body;
+};

--- a/test/http/cgi/cgi_response_test.hpp
+++ b/test/http/cgi/cgi_response_test.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "../../../src/http/request/http_fields.hpp"
+#include "../../../src/http/cgi/cgi_response.hpp"
 #include "../../../src/http/http_status.hpp"
 
 class CgiResponseTest {
@@ -11,6 +12,7 @@ class CgiResponseTest {
     std::string request;
     bool isSuccessTest;
     http::HttpStatus httpStatus;
+    http::CgiResponse::CgiType cgiType;
     http::HTTPFields::FieldMap exceptMap;
     std::string body;
 };

--- a/test/http/cgi/cgi_response_testcase.cpp
+++ b/test/http/cgi/cgi_response_testcase.cpp
@@ -1,0 +1,224 @@
+// Copyright 2025 Ideal Broccoli
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include <cstdio>
+
+#include "../../../toolbox/stepmark.hpp"
+#include "../../../src/http/cgi/cgi_response_parser.hpp"
+#include "cgi_response_test.hpp"
+
+typedef std::vector<CgiResponseTest> TestVector;
+
+void showField(http::CgiResponseParser& r, CgiResponseTest& t) {
+    std::cout << "----- field -----" << std::endl;
+    std::cout << "nginx status  : " << t.httpStatus.get() << std::endl;
+    std::cout << "webserv status: " << r.get().httpStatus.get() << std::endl;
+    for (http::HTTPFields::FieldMap::iterator it = r.get().fields.get().begin();
+                it != r.get().fields.get().end(); ++it) {
+        if (!it->second.empty()) {
+            std::cout << "webserv: " << it->first << " ";
+            for (std::size_t i = 0; i < it->second.size(); ++i) {
+                std::cout << it->second[i] << ", ";
+            }
+            std::cout << std::endl;
+            http::HTTPFields::FieldMap::iterator it_t =
+                t.exceptMap.find(it->first);
+            if (it_t == t.exceptMap.end()) {
+                continue;
+            }
+            std::cout << "nginx  : " << it_t->first << " ";
+            for (std::size_t i = 0; i < it_t->second.size(); ++i) {
+                std::cout << it_t->second[i] << ", ";
+            }
+            std::cout << std::endl;
+        }
+    }
+}
+
+bool compareFields(http::CgiResponseParser& r, CgiResponseTest& t) {
+    if (r.get().httpStatus.get() != t.httpStatus.get()) {
+        return false;
+    }
+    for (http::HTTPFields::FieldMap::iterator it_r =
+            r.get().fields.get().begin();
+            it_r != r.get().fields.get().end(); ++it_r) {
+                http::HTTPFields::FieldMap::iterator it_t
+                    = t.exceptMap.find(it_r->first);
+        if (it_r->second.empty()) {
+            if (it_t == t.exceptMap.end()) {
+                continue;
+            }
+            return false;
+        }
+        if (it_t->second.empty() || it_r->second != it_t->second) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool runTest(CgiResponseTest& t) {
+    toolbox::logger::StepMark::debug(t.name);
+    http::CgiResponseParser r;
+    try {
+        r.run(t.request);
+    } catch (std::exception& e) {
+    }
+    if (t.isSuccessTest && compareFields(r, t)) {
+        return true;
+    } else if (t.isSuccessTest) {
+        std::cout << "==== Failed: true->false "
+            << t.name << " ====" << std::endl;
+        showField(r, t);
+        return false;
+    } else if (!t.isSuccessTest && compareFields(r, t)) {
+        return true;
+    } else {
+        std::cout << "==== Failed: false->true "
+            << t.name << " ====" << std::endl;
+        showField(r, t);
+        return false;
+    }
+}
+
+void addFieldToMap(http::HTTPFields::FieldMap& map,
+    const std::string& key,
+    const std::string& value) {
+map[key].push_back(value);
+}
+
+void makeCgiDefaultTests(TestVector& t) {
+    CgiResponseTest r;
+
+    r.name = "基本的なCGIレスポンス";
+
+    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
+                "<head>\r\n\t<title>CGIResponseSample</title>\r\n</head>\r\n"
+                "<body>\r\n\t<h1>Hello, World!</h1>\r\n"
+                "\t<p>This is CGI response sample text</p>\r\n</body>\r\n"
+                "</html>\r\n";
+    r.request = "Content-Type: text/html\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::OK);
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "リダイレクトCGIレスポンス";
+    r.body = "";
+    r.request = "Location: https://example.com/new-location\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::FOUND);
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location", "https://example.com/new-location");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "カスタムステータスCGIレスポンス";
+    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
+            "<body>\r\n\t<h1>Not Found</h1>\r\n"
+            "\t<p>The requested resource was not found on this server.</p>\r\n"
+            "</body>\r\n</html>\r\n";
+    r.request = "Status: 404 Not Found\r\nContent-Type: text/html\r\n\r\n"
+        + r.body;
+    r.httpStatus.set(http::HttpStatus::NOT_FOUND);
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "JSON CGIレスポンス";
+    r.body = "{\r\n\t\"status\": \"success\",\r\n"
+            "\t\"data\": {\r\n"
+            "\t\t\"id\": 123,\r\n"
+            "\t\t\"name\": \"サンプルデータ\"\r\n"
+            "\t}\r\n}\r\n";
+    r.request = "Content-Type: application/json\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::OK);
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "application/json");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "リダイレクト+ステータスCGIレスポンス";
+    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
+            "<body>\r\n\t<h1>Moved Permanently</h1>\r\n"
+            "\t<p>The document has moved "
+            "<a href=\"https://example.com/permanent\">here</a>"
+            ".</p>\r\n</body>\r\n</html>\r\n";
+    r.request = "Status: 301 Moved Permanently\r\n"
+        "Location: https://example.com/permanent\r\n"
+        "Content-Type: text/html\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::MOVED_PERMANENTLY);
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
+    addFieldToMap(r.exceptMap, "Location", "https://example.com/permanent");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    // テストケース5: Content-Length指定あり
+    r.name = "Content-Length付きCGIレスポンス";
+    r.body = "Hello, World!";
+    r.request = "Content-Type: text/plain\r\n"
+        "Content-Length: 13\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::OK);
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/plain");
+    addFieldToMap(r.exceptMap, "Content-Length", "13");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    // テストケース6: Set-Cookieヘッダー
+    r.name = "クッキー設定CGIレスポンス";
+    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
+            "<body>\r\n\t<h1>Cookie Set</h1>\r\n"
+            "\t<p>A cookie has been set for your session.</p>\r\n</body>\r\n"
+            "</html>\r\n";
+    r.request = "Content-Type: text/html\r\n"
+        "Set-Cookie: session=abc123; Path=/; HttpOnly\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::OK);
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
+    addFieldToMap
+        (r.exceptMap, "Set-Cookie", "session=abc123; Path=/; HttpOnly");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    // テストケース7: NPHスクリプト風（エラーテスト）
+    r.name = "疑似NPHスクリプトテスト（エラー）";
+    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
+            "<body>\r\n\t<h1>Error</h1>\r\n"
+            "\t<p>This test is expected to fail as it's missing proper"
+            " headers.</p>\r\n</body>\r\n"
+            "</html>\r\n";
+    r.request = "HTTP/1.1 200 OK\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::INTERNAL_SERVER_ERROR);
+    r.isSuccessTest = false;  // 失敗を期待するテスト
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    // テストケース8: 不正なヘッダーフォーマット
+    r.name = "不正なヘッダーフォーマット";
+    r.body = "エラーメッセージ";
+    r.request = "Content Type: text/plain\r\n\r\n" + r.body;  // スペースが不正
+    r.httpStatus.set(http::HttpStatus::INTERNAL_SERVER_ERROR);
+    r.isSuccessTest = false;
+    t.push_back(r);
+    r.exceptMap.clear();
+}
+
+void requestLineTest() {
+    TestVector tests;
+    makeCgiDefaultTests(tests);
+
+    std::size_t pass = 0;
+    for (std::size_t i = 0; i < tests.size(); ++i) {
+        if (runTest(tests[i])) {
+            ++pass;
+        }
+    }
+    std::cout << "RequestLine testcase " << pass << " / "
+        << tests.size() << std::endl;
+}

--- a/test/http/cgi/cgi_response_testcase.cpp
+++ b/test/http/cgi/cgi_response_testcase.cpp
@@ -16,6 +16,8 @@ void showField(http::CgiResponseParser& r, CgiResponseTest& t) {
     std::cout << "----- field -----" << std::endl;
     std::cout << "nginx status  : " << t.httpStatus.get() << std::endl;
     std::cout << "webserv status: " << r.get().httpStatus.get() << std::endl;
+    std::cout << "nginx cgiType  : " << t.cgiType << std::endl;
+    std::cout << "webserv cgiType: " << r.get().cgiType << std::endl;
     for (http::HTTPFields::FieldMap::iterator it = r.get().fields.get().begin();
                 it != r.get().fields.get().end(); ++it) {
         if (!it->second.empty()) {
@@ -42,6 +44,9 @@ bool compareFields(http::CgiResponseParser& r, CgiResponseTest& t) {
     if (r.get().httpStatus.get() != t.httpStatus.get()) {
         return false;
     }
+    if (r.get().cgiType != t.cgiType) {
+        return false;
+    }
     for (http::HTTPFields::FieldMap::iterator it_r =
             r.get().fields.get().begin();
             it_r != r.get().fields.get().end(); ++it_r) {
@@ -65,6 +70,7 @@ bool runTest(CgiResponseTest& t) {
     http::CgiResponseParser r;
     try {
         r.run(t.request);
+        r.get().identifyCgiType();
     } catch (std::exception& e) {
     }
     if (t.isSuccessTest && compareFields(r, t)) {
@@ -90,46 +96,24 @@ void addFieldToMap(http::HTTPFields::FieldMap& map,
 map[key].push_back(value);
 }
 
-void makeCgiDefaultTests(TestVector& t) {
+void makeDocumentCgiTests(TestVector& t) {
     CgiResponseTest r;
 
-    r.name = "基本的なCGIレスポンス";
-
+    r.name = "基本的なHTMLドキュメント";
     r.body = "<!DOCTYPE html>\r\n<html>\r\n"
-                "<head>\r\n\t<title>CGIResponseSample</title>\r\n</head>\r\n"
-                "<body>\r\n\t<h1>Hello, World!</h1>\r\n"
-                "\t<p>This is CGI response sample text</p>\r\n</body>\r\n"
-                "</html>\r\n";
+                "<head>\r\n\t<title>CGIドキュメントサンプル</title>\r\n"
+                "</head>\r\n<body>\r\n\t<h1>こんにちは、世界！</h1>\r\n"
+                "\t<p>これはCGIレスポンスのサンプルテキストです</p>\r\n"
+                "</body>\r\n</html>\r\n";
     r.request = "Content-Type: text/html\r\n\r\n" + r.body;
     r.httpStatus.set(http::HttpStatus::OK);
+    r.cgiType = http::CgiResponse::DOCUMENT;
     r.isSuccessTest = true;
     addFieldToMap(r.exceptMap, "Content-Type", "text/html");
     t.push_back(r);
     r.exceptMap.clear();
 
-    r.name = "リダイレクトCGIレスポンス";
-    r.body = "";
-    r.request = "Location: https://example.com/new-location\r\n\r\n" + r.body;
-    r.httpStatus.set(http::HttpStatus::FOUND);
-    r.isSuccessTest = true;
-    addFieldToMap(r.exceptMap, "Location", "https://example.com/new-location");
-    t.push_back(r);
-    r.exceptMap.clear();
-
-    r.name = "カスタムステータスCGIレスポンス";
-    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
-            "<body>\r\n\t<h1>Not Found</h1>\r\n"
-            "\t<p>The requested resource was not found on this server.</p>\r\n"
-            "</body>\r\n</html>\r\n";
-    r.request = "Status: 404 Not Found\r\nContent-Type: text/html\r\n\r\n"
-        + r.body;
-    r.httpStatus.set(http::HttpStatus::NOT_FOUND);
-    r.isSuccessTest = true;
-    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
-    t.push_back(r);
-    r.exceptMap.clear();
-
-    r.name = "JSON CGIレスポンス";
+    r.name = "JSONドキュメント";
     r.body = "{\r\n\t\"status\": \"success\",\r\n"
             "\t\"data\": {\r\n"
             "\t\t\"id\": 123,\r\n"
@@ -137,12 +121,223 @@ void makeCgiDefaultTests(TestVector& t) {
             "\t}\r\n}\r\n";
     r.request = "Content-Type: application/json\r\n\r\n" + r.body;
     r.httpStatus.set(http::HttpStatus::OK);
+    r.cgiType = http::CgiResponse::DOCUMENT;
     r.isSuccessTest = true;
     addFieldToMap(r.exceptMap, "Content-Type", "application/json");
     t.push_back(r);
     r.exceptMap.clear();
 
-    r.name = "リダイレクト+ステータスCGIレスポンス";
+    r.name = "Content-Length付きテキストドキュメント";
+    r.body = "Hello, World!";
+    r.request = "Content-Type: text/plain\r\n"
+        "Content-Length: 13\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::OK);
+    r.cgiType = http::CgiResponse::DOCUMENT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/plain");
+    addFieldToMap(r.exceptMap, "Content-Length", "13");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "クッキー設定付きドキュメント";
+    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
+            "<body>\r\n\t<h1>クッキーが設定されました</h1>\r\n"
+            "\t<p>セッション用のクッキーが設定されました。</p>\r\n</body>\r\n"
+            "</html>\r\n";
+    r.request = "Content-Type: text/html\r\n"
+        "Set-Cookie: session=abc123; Path=/; HttpOnly\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::OK);
+    r.cgiType = http::CgiResponse::DOCUMENT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
+    addFieldToMap(r.exceptMap, "Set-Cookie",
+        "session=abc123; Path=/; HttpOnly");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "カスタムステータスとヘッダーのドキュメント";
+    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
+            "<body>\r\n\t<h1>Not Found</h1>\r\n"
+            "\t<p>リクエストされたリソースは見つかりませんでした。</p>\r\n"
+            "</body>\r\n</html>\r\n";
+    r.request = "Status: 404 Not Found\r\n"
+        "Content-Type: text/html\r\n"
+        "X-Custom-Header: CustomValue\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::NOT_FOUND);
+    r.cgiType = http::CgiResponse::DOCUMENT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
+    addFieldToMap(r.exceptMap, "X-Custom-Header", "CustomValue");
+    t.push_back(r);
+    r.exceptMap.clear();
+}
+
+void makeLocalRedirectCgiTests(TestVector& t) {
+    CgiResponseTest r;
+
+    r.name = "基本的なローカルリダイレクト";
+    r.body = "";
+    r.request = "Location: /new-location\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::LOCAL_REDIRECT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location", "/new-location");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "絶対パスへのローカルリダイレクト";
+    r.body = "";
+    r.request = "Location: /absolute/path/resource\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::LOCAL_REDIRECT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location", "/absolute/path/resource");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "相対パスへのローカルリダイレクト";
+    r.body = "";
+    r.request = "Location: ../parent/resource\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::INVALID;
+    r.isSuccessTest = false;
+    addFieldToMap(r.exceptMap, "Location", "../parent/resource");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "クエリパラメータ付きローカルリダイレクト";
+    r.body = "";
+    r.request = "Location: /search?q=test&page=1\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::LOCAL_REDIRECT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location", "/search?q=test&page=1");
+    t.push_back(r);
+    r.exceptMap.clear();
+}
+
+void makeClientRedirectTests(TestVector& t) {
+    CgiResponseTest r;
+
+    r.name = "基本的なクライアントリダイレクト";
+    r.body = "";
+    r.request = "Location: https://example.com/new-location\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location", "https://example.com/new-location");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "外部サイトへのリダイレクト";
+    r.body = "";
+    r.request = "Location: https://external-site.org/resource\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location",
+        "https://external-site.org/resource");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "クエリパラメータ付きリダイレクト";
+    r.body = "";
+    r.request ="Location: https://example.com/search"
+        "?q=webserv&category=project\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location",
+        "https://example.com/search?q=webserv&category=project");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "フラグメント識別子付きリダイレクト";
+    r.body = "";
+    r.request = "Location: https://example.com/page#section2\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location", "https://example.com/page#section2");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "相対URLへのリダイレクト";
+    r.body = "";
+    r.request = "Location: ../parent/resource\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::INVALID;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location", "../parent/resource");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "追加ヘッダー付きリダイレクト";
+    r.body = "";
+    r.request = "Location: https://example.com/redirect\r\n"
+                "Cache-Control: no-cache\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::INVALID;
+    r.isSuccessTest = false;
+    addFieldToMap(r.exceptMap, "Location", "https://example.com/redirect");
+    addFieldToMap(r.exceptMap, "Cache-Control", "no-cache");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "ポート指定付きリダイレクト";
+    r.body = "";
+    r.request = "Location: https://example.com:8080/custom-port\r\n\r\n"
+        + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location",
+        "https://example.com:8080/custom-port");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "プロトコルなしURLへのリダイレクト";
+    r.body = "";
+    r.request = "Location: //example.com/protocol-relative\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::INVALID;
+    r.isSuccessTest = false;
+    addFieldToMap(r.exceptMap, "Location", "//example.com/protocol-relative");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "ローカルホストへのリダイレクト";
+    r.body = "";
+    r.request = "Location: http://localhost:8080/test\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Location", "http://localhost:8080/test");
+    t.push_back(r);
+    r.exceptMap.clear();
+}
+
+void makeClientRedirectWithDocumentTests(TestVector& t) {
+    CgiResponseTest r;
+
+    r.name = "基本的なクライアントリダイレクト";
+    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
+            "<body>\r\n\t<h1>Found</h1>\r\n"
+            "\t<p>The document has moved "
+            "<a href=\"https://example.com/temp\">here</a>"
+            ".</p>\r\n</body>\r\n</html>\r\n";
+    r.request = "Status: 302 Found\r\n"
+        "Location: https://example.com/temp\r\n"
+        "Content-Type: text/html\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::FOUND);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT_DOCUMENT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
+    addFieldToMap(r.exceptMap, "Location", "https://example.com/temp");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "永続的クライアントリダイレクト";
     r.body = "<!DOCTYPE html>\r\n<html>\r\n"
             "<body>\r\n\t<h1>Moved Permanently</h1>\r\n"
             "\t<p>The document has moved "
@@ -152,66 +347,129 @@ void makeCgiDefaultTests(TestVector& t) {
         "Location: https://example.com/permanent\r\n"
         "Content-Type: text/html\r\n\r\n" + r.body;
     r.httpStatus.set(http::HttpStatus::MOVED_PERMANENTLY);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT_DOCUMENT;
     r.isSuccessTest = true;
     addFieldToMap(r.exceptMap, "Content-Type", "text/html");
     addFieldToMap(r.exceptMap, "Location", "https://example.com/permanent");
     t.push_back(r);
     r.exceptMap.clear();
 
-    // テストケース5: Content-Length指定あり
-    r.name = "Content-Length付きCGIレスポンス";
-    r.body = "Hello, World!";
-    r.request = "Content-Type: text/plain\r\n"
-        "Content-Length: 13\r\n\r\n" + r.body;
-    r.httpStatus.set(http::HttpStatus::OK);
-    r.isSuccessTest = true;
-    addFieldToMap(r.exceptMap, "Content-Type", "text/plain");
-    addFieldToMap(r.exceptMap, "Content-Length", "13");
-    t.push_back(r);
-    r.exceptMap.clear();
-
-    // テストケース6: Set-Cookieヘッダー
-    r.name = "クッキー設定CGIレスポンス";
+    r.name = "別ドメインへのクライアントリダイレクト";
     r.body = "<!DOCTYPE html>\r\n<html>\r\n"
-            "<body>\r\n\t<h1>Cookie Set</h1>\r\n"
-            "\t<p>A cookie has been set for your session.</p>\r\n</body>\r\n"
+            "<body>\r\n\t<h1>Redirect</h1>\r\n"
+            "\t<p>リダイレクト中...</p>\r\n</body>\r\n"
             "</html>\r\n";
-    r.request = "Content-Type: text/html\r\n"
-        "Set-Cookie: session=abc123; Path=/; HttpOnly\r\n\r\n" + r.body;
-    r.httpStatus.set(http::HttpStatus::OK);
+    r.request = "Status: 302 Found\r\n"
+        "Location: https://otherdomain.com/resource\r\n"
+        "Content-Type: text/html\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::FOUND);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT_DOCUMENT;
     r.isSuccessTest = true;
     addFieldToMap(r.exceptMap, "Content-Type", "text/html");
-    addFieldToMap
-        (r.exceptMap, "Set-Cookie", "session=abc123; Path=/; HttpOnly");
+    addFieldToMap(r.exceptMap, "Location", "https://otherdomain.com/resource");
     t.push_back(r);
     r.exceptMap.clear();
 
-    // テストケース7: NPHスクリプト風（エラーテスト）
-    r.name = "疑似NPHスクリプトテスト（エラー）";
+    r.name = "一時的リダイレクト";
     r.body = "<!DOCTYPE html>\r\n<html>\r\n"
-            "<body>\r\n\t<h1>Error</h1>\r\n"
-            "\t<p>This test is expected to fail as it's missing proper"
-            " headers.</p>\r\n</body>\r\n"
+            "<body>\r\n\t<h1>Temporary Redirect</h1>\r\n"
+            "\t<p>一時的にリダイレクトされています</p>\r\n</body>\r\n"
             "</html>\r\n";
-    r.request = "HTTP/1.1 200 OK\r\n\r\n" + r.body;
-    r.httpStatus.set(http::HttpStatus::INTERNAL_SERVER_ERROR);
-    r.isSuccessTest = false;  // 失敗を期待するテスト
+    r.request = "Status: 307 Temporary Redirect\r\n"
+        "Location: https://example.com/temporary\r\n"
+        "Content-Type: text/html\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::TEMPORARY_REDIRECT);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT_DOCUMENT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
+    addFieldToMap(r.exceptMap, "Location", "https://example.com/temporary");
     t.push_back(r);
     r.exceptMap.clear();
 
-    // テストケース8: 不正なヘッダーフォーマット
+    r.name = "カスタムヘッダー付きクライアントリダイレクト";
+    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
+            "<body>\r\n\t<h1>リダイレクト</h1>\r\n"
+            "\t<p>カスタムヘッダー付きのリダイレクトです</p>\r\n</body>\r\n"
+            "</html>\r\n";
+    r.request = "Status: 302 Found\r\n"
+        "Location: https://example.com/custom\r\n"
+        "Content-Type: text/html\r\n"
+        "X-Redirect-Reason: Maintenance\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::FOUND);
+    r.cgiType = http::CgiResponse::CLIENT_REDIRECT_DOCUMENT;
+    r.isSuccessTest = true;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
+    addFieldToMap(r.exceptMap, "Location", "https://example.com/custom");
+    addFieldToMap(r.exceptMap, "X-Redirect-Reason", "Maintenance");
+    t.push_back(r);
+    r.exceptMap.clear();
+}
+
+void makeInvalidCgiTests(TestVector& t) {
+    CgiResponseTest r;
+
     r.name = "不正なヘッダーフォーマット";
     r.body = "エラーメッセージ";
     r.request = "Content Type: text/plain\r\n\r\n" + r.body;  // スペースが不正
     r.httpStatus.set(http::HttpStatus::INTERNAL_SERVER_ERROR);
+    r.cgiType = http::CgiResponse::INVALID;
     r.isSuccessTest = false;
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "存在しないステータスコード";
+    r.body = "<!DOCTYPE html>\r\n<html>\r\n"
+            "<body>\r\n\t<h1>エラー</h1>\r\n"
+            "\t<p>不正なステータスコード</p>\r\n</body>\r\n"
+            "</html>\r\n";
+    r.request = "Status: 999 Invalid Status\r\n"
+        "Content-Type: text/html\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::INTERNAL_SERVER_ERROR);
+    r.cgiType = http::CgiResponse::INVALID;
+    r.isSuccessTest = false;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/html");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "不正なContent-Length";
+    r.body = "テスト本文";
+    r.request = "Content-Type: text/plain\r\n"
+        "Content-Length: invalid\r\n\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::INTERNAL_SERVER_ERROR);
+    r.cgiType = http::CgiResponse::INVALID;
+    r.isSuccessTest = false;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/plain");
+    addFieldToMap(r.exceptMap, "Content-Length", "invalid");
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "空のリクエスト";
+    r.body = "";
+    r.request = "";
+    r.httpStatus.set(http::HttpStatus::UNSET);
+    r.cgiType = http::CgiResponse::INVALID;
+    r.isSuccessTest = false;
+    t.push_back(r);
+    r.exceptMap.clear();
+
+    r.name = "ヘッダーとボディの区切りがない";
+    r.body = "ボディ部分";
+    r.request = "Content-Type: text/plain\r\n" + r.body;
+    r.httpStatus.set(http::HttpStatus::OK);
+    r.cgiType = http::CgiResponse::DOCUMENT;
+    r.isSuccessTest = false;
+    addFieldToMap(r.exceptMap, "Content-Type", "text/plain");
     t.push_back(r);
     r.exceptMap.clear();
 }
 
 void requestLineTest() {
     TestVector tests;
-    makeCgiDefaultTests(tests);
+    makeDocumentCgiTests(tests);
+    makeLocalRedirectCgiTests(tests);
+    makeClientRedirectWithDocumentTests(tests);
+    makeClientRedirectTests(tests);
+    makeInvalidCgiTests(tests);
 
     std::size_t pass = 0;
     for (std::size_t i = 0; i < tests.size(); ++i) {

--- a/test/http/cgi/main.cpp
+++ b/test/http/cgi/main.cpp
@@ -1,0 +1,12 @@
+#include "../../../src/http/cgi/cgi_response_parser.hpp"
+#include "cgi_response_test.hpp"
+
+void requestLineTest();
+
+int main(void) {
+    toolbox::logger::StepMark::setLogFile("cgi_test.log");
+    toolbox::logger::StepMark::setLevel(toolbox::logger::DEBUG);
+    requestLineTest();
+
+    return 0;
+}

--- a/test/http/request/buf_size_test.cpp
+++ b/test/http/request/buf_size_test.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <cassert>
+#include "../../../src/http/request/request_parser.hpp"
+
+std::string statusToString(http::BaseParser::ParseStatus status);
+
+void testRequestParser() {
+    http::RequestParser parser;
+    std::string request =
+        "GET /index.html HTTP/1.1\r\n"
+        "Host: example.com\r\n"
+        "Content-Length: 13\r\n"
+        "\r\n"
+        "Hello, World!";
+    const size_t BUFFER_SIZE = 10;
+
+    size_t pos = 0;
+    http::BaseParser::ParseStatus status = http::BaseParser::P_IN_PROGRESS;
+
+    std::cout << "===== テスト開始 =====\n";
+
+    while (pos < request.size() && status != http::BaseParser::P_ERROR) {
+        size_t chunk_size = std::min(BUFFER_SIZE, request.size() - pos);
+        std::string chunk = request.substr(pos, chunk_size);
+        pos += chunk_size;
+
+        status = parser.run(chunk);
+
+        std::cout << "チャンク処理: [" << chunk << "]\n";
+        std::cout << "ステータス: " << statusToString(status) << "\n";
+
+        if (status == http::BaseParser::P_COMPLETED) {
+            http::HTTPRequest& req = parser.get();
+            std::cout << "パース完了:\n";
+            std::cout << "  メソッド: " << req.method << "\n";
+            std::cout << "  URI: " << req.uri.fullUri << "\n";
+            std::cout << "  バージョン: " << req.version << "\n";
+            std::cout << "  ホスト: " << req.fields.getFieldValue("Host")[0] << "\n";
+            std::cout << "  ボディ: " << req.body.content << "\n";
+
+            assert(req.method == "GET");
+            assert(req.uri.fullUri == "/index.html");
+            assert(req.version == "HTTP/1.1");
+            assert(req.fields.getFieldValue("Host")[0] == "example.com");
+            assert(req.body.content == "Hello, World!");
+        } else if (status == http::BaseParser::P_ERROR) {
+            std::cout << "エラー発生: HTTPステータス " 
+                      << parser.get().httpStatus.get() << "\n";
+        }
+    }
+
+    std::cout << "===== テスト終了 =====\n";
+    if (status == http::BaseParser::P_COMPLETED) {
+        std::cout << "テスト成功: リクエストが正しく解析されました\n";
+    } else {
+        std::cout << "テスト失敗: リクエストの解析が完了しませんでした\n";
+    }
+}
+
+std::string statusToString(http::BaseParser::ParseStatus status) {
+    switch (status) {
+        case http::BaseParser::P_IN_PROGRESS:
+            return "処理中";
+        case http::BaseParser::P_NEED_MORE_DATA:
+            return "データ不足";
+        case http::BaseParser::P_COMPLETED:
+            return "完了";
+        case http::BaseParser::P_ERROR:
+            return "エラー";
+        default:
+            return "不明";
+    }
+}

--- a/test/http/request/requestline_testcase.cpp
+++ b/test/http/request/requestline_testcase.cpp
@@ -19,7 +19,7 @@ bool compareRequestLine(http::RequestParser& r, RequestLineTest& t) {
     if (r.get().method != t._exceptRequest.method ||
         r.get().uri.path != t._exceptRequest.path ||
         r.get().version != t._exceptRequest.version) {
-            return false;
+        return false;
     }
     for (std::size_t i = 0; i < t._exceptRequest.queryVec.size(); ++i) {
         QueryMap::iterator it =
@@ -763,7 +763,7 @@ void makePercentEncodingTests(TestVector& t) {
     r._httpStatus.set(http::HttpStatus::OK);  // will Not Found
     r._isSuccessTest = true;
     r._exceptRequest.method = "GET";
-    r._exceptRequest.path = "/test%0A%0D.html";
+    r._exceptRequest.path = "/test\n\r.html";
     r._exceptRequest.version = "HTTP/1.1";
     t.push_back(r);
     clearUri(r);

--- a/test/http/request/test_main.cpp
+++ b/test/http/request/test_main.cpp
@@ -4,12 +4,14 @@
 
 void requestLineTest();
 void fieldTest();
+void testRequestParser();
 
 int main(void) {
     toolbox::logger::StepMark::setLogFile("request_test.log");
     toolbox::logger::StepMark::setLevel(toolbox::logger::DEBUG);
     requestLineTest();
     fieldTest();
+    testRequestParser();
 
     return 0;
 }


### PR DESCRIPTION
## 概要
cgiresponseparserクラスの作成
## 変更内容

* #58 で作成したBaseParserクラスを基底クラスとしたCgiResponseParserクラスを作成
*  RFC 3875 改行がCRLFでない場合があるとの記載があったためLF単体の場合でも対応できるようにした
> the character sequence for newline (such as UNIX's US-ASCII LF) used by CGI scripts may not be the same as that used by HTTP (US-ASCII CR followed by LF).
* status FieldはHttpStatusとして保持している。
　* 数値とそれに続く文章が正しいか確認するためにresponseクラスのgetStatusMessageをstaticに変更し活用している(あまりよくない変更であれば戻して別の方法を考えます)

## 関連Issue

* #58 #43 

## 影響範囲

* src/http/cgi
* src/http/response/getStatusMessage.c/hpp
* test/http/cgi

## テスト

* test/http/cgiでmakeを実行し、作成されたファイルを実行してください。 

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | `CgiFieldParser`クラスと`CgiResponse`クラスが追加され、CGIフィールドとレスポンスの解析機能が強化されました。 |
| Refactor | `RequestParser`や`FieldValidator`などのメソッドシグネチャが改善され、コードの保守性が向上しました。 |
| Bug fix | ヘッダー検証ロジックが修正され、HTTPリクエストの処理がより正確になりました。 |

このプルリクエストでは、新しい機能の追加と既存コードのリファクタリングがバランスよく行われており、特にCGI関連の処理が大幅に改善されています。全体的なコード品質が向上し、今後の開発が容易になる点が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->