### PR TITLE
refactor: get method update/fix

### DIFF
--- a/src/http/http_status.hpp
+++ b/src/http/http_status.hpp
@@ -50,7 +50,7 @@ class HttpStatus {
         BAD_GATEWAY = 502,
         SERVICE_UNAVAILABLE = 503,
         GATEWAY_TIMEOUT = 504,
-        HTTP_VERSION_NOT_SUPPORTED = 505
+        HTTP_VERSION_NOT_SUPPORTED = 505,
     };
 
     HttpStatus() : _status(OK) {}

--- a/src/http/response/get_method.hpp
+++ b/src/http/response/get_method.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include "../case_insensitive_less.hpp"
+#include "../http_status.hpp"
+
+namespace http {
+
+typedef std::map<std::string, std::string, CaseInsensitiveLess> ExtensionMap;
+
+void initExtensionMap(ExtensionMap& extensionMap);
+HttpStatus::EHttpStatus runGet(const std::string& path,
+                             std::string& responseBody,
+                             const std::string& indexPath,
+                             bool isAutoindex,
+                             std::string& contentType,
+                             ExtensionMap& extensionMap);
+void readDirectoryEntries(const std::string& dirPath,
+                          std::string& responseBody);
+
+}  // namespace http

--- a/test/http/response/method/get.cpp
+++ b/test/http/response/method/get.cpp
@@ -11,14 +11,7 @@
 
 #include "../../../../src/http/http_status.hpp"
 #include "../../../../src/http/case_insensitive_less.hpp"
-
-typedef std::map<std::string, std::string, http::CaseInsensitiveLess>
-ExtentionMap;
-
-http::HttpStatus runGet(const std::string& path, std::string& responseBody,
-    const std::string& indexPath, bool isAutoindex, std::string& contentType,
-    ExtentionMap& extensionMap);
-void initExtensionMap(ExtentionMap& extensionMap);
+#include "../../../../src/http/response/get_method.hpp"
 
 void setupTestEnvironment() {
     mkdir("./test_dir", 0755);
@@ -55,16 +48,16 @@ void cleanupTestEnvironment() {
 void runTests() {
     std::string responseBody;
     std::string contentType;
-    ExtentionMap extensionMap;
-    initExtensionMap(extensionMap);
-    http::HttpStatus status;
+    http::ExtensionMap extensionMap;
+    http::initExtensionMap(extensionMap);
+    http::HttpStatus::EHttpStatus status;
 
     std::cout << "===== get nomal file =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/test.html", responseBody, "", false,
+    status = http::runGet("./test_dir/test.html", responseBody, "", false,
         contentType, extensionMap);
-    assert(status == http::OK);
+    assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
     assert(responseBody.find("Test HTML") != std::string::npos);
     std::cout << "OK: " << status << std::endl;
@@ -72,17 +65,17 @@ void runTests() {
     std::cout << "===== get nonexistent file =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/nonexistent.html", responseBody, "", false,
+    status = http::runGet("./test_dir/nonexistent.html", responseBody, "", false,
         contentType, extensionMap);
-    assert(status == http::NOT_FOUND);
+    assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get dir indexfile =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/", responseBody, "index.html", false,
+    status = http::runGet("./test_dir/", responseBody, "index.html", false,
         contentType, extensionMap);
-    assert(status == http::OK);
+    assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
     assert(responseBody.find("Index HTML") != std::string::npos);
     std::cout << "OK: " << status << std::endl;
@@ -90,9 +83,9 @@ void runTests() {
     std::cout << "===== get dir autoindex =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/", responseBody, "", true,
+    status = http::runGet("./test_dir/", responseBody, "", true,
         contentType, extensionMap);
-    assert(status == http::OK);
+    assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
     assert(responseBody.find("Index of") != std::string::npos);
     std::cout << "OK: " << status << std::endl;
@@ -100,35 +93,35 @@ void runTests() {
     std::cout << "===== get no permission =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/no_permission.html", responseBody, "",
+    status = http::runGet("./test_dir/no_permission.html", responseBody, "",
         false, contentType, extensionMap);
-    assert(status == http::FORBIDDEN);
+    assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get empty dir ====="
         << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/empty_dir/", responseBody, "", true,
+    status = http::runGet("./test_dir/empty_dir/", responseBody, "", true,
         contentType, extensionMap);
-    assert(status == http::OK);
+    assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get empty dir indexfile =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/empty_dir/", responseBody, "index.html",
+    status = http::runGet("./test_dir/empty_dir/", responseBody, "index.html",
         false, contentType, extensionMap);
-    assert(status == http::NOT_FOUND);
+    assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get no permission dir =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/no_permission_dir/", responseBody, "",
+    status = http::runGet("./test_dir/no_permission_dir/", responseBody, "",
         true, contentType, extensionMap);
-    assert(status == http::FORBIDDEN);
+    assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 }
 


### PR DESCRIPTION
~

## 概要
GETメソッドの実装で過去のenumを使用していた部分をアップデートする
## 変更内容

* http::ok -> http::HttpStatus::okに変更
* checkFileAccess関数でstat->accessの順番で使用していたが、accessした後にstatを呼び出すように修正

## 関連Issue

* #68 

## 影響範囲

* src/htto/response/get_method.c/hpp
* test/http/response/method/get.cpp

## テスト

* test/http/response/method/ make
以前と同様のテストが動きます

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | HTTPステータスコードのenum使用により、コードの一貫性と可読性が向上しました。 |
| Refactor | `checkFileAccess`関数のファイルアクセスチェックの順序を変更し、効率化を図りました。 |
| Refactor | 名前空間の整理と新しいヘッダーファイルの導入により、モジュール性が改善されました。 |
| Test | テストコードでの名前空間の使用を統一し、HTTPステータスコードの参照を更新しました。 |

このプルリクエストでは、コードの一貫性と可読性を高めるためのリファクタリングが行われており、特に名前空間の整理やenumの使用が効果的です。これにより、保守性が大幅に向上しています。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->