### PR TITLE
74 access logを作る

### DIFF
--- a/test/toolbox/accesslog/Makefile
+++ b/test/toolbox/accesslog/Makefile
@@ -1,0 +1,25 @@
+NAME = accesslog_test.out
+
+SRCS = main.cpp ../../../toolbox/access.cpp
+OBJS = $(SRCS:.cpp=.o)
+
+CXX = c++
+CXXFLAGS = -Wall -Wextra -Werror -std=c++98
+
+run: $(NAME)
+	./$(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJS)
+
+clean:
+	rm -f $(OBJS) $(NAME)
+
+fclean: clean
+	rm -f $(NAME)
+
+re: fclean all
+
+all: $(NAME)
+
+.PHONY: all clean fclean re run

--- a/test/toolbox/accesslog/main.cpp
+++ b/test/toolbox/accesslog/main.cpp
@@ -1,0 +1,34 @@
+
+#include "../../../toolbox/access.hpp"
+
+int main() {
+    toolbox::logger::AccessLog::setLogFile("special_access.log");
+    toolbox::logger::AccessLog::log(
+        "127.0.0.1",
+        "user",
+        "GET /index.html HTTP/1.1",
+        200,
+        1234,
+        "http://example.com",
+        "curl/7.64.1"
+    );
+    toolbox::logger::AccessLog::log(
+        "127.0.0.1",
+        "user",
+        "GET /index.html HTTP/1.1",
+        200,
+        1234,
+        "http://example.com",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+    );
+    toolbox::logger::AccessLog::setLogFile("access.log");
+    toolbox::logger::AccessLog::log(
+        "127.0.0.1",
+        "-",
+        "GET /index.html HTTP/1.1",
+        200,
+        1234,
+        "http://example.com",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+    );
+}

--- a/toolbox/access.cpp
+++ b/toolbox/access.cpp
@@ -92,11 +92,11 @@ void logger::AccessLog::log(
 }
 
 std::string logger::AccessLog::getTimeStamp() {
-    std::time_t now = std::time(nullptr);
-    std::tm* tm_now = std::gmtime(&now);
-    std::ostringstream oss;
-    oss << std::put_time(tm_now, "%d/%b/%Y:%H:%M:%S %z");
-    return oss.str();
+    std::time_t now = std::time(NULL);
+    std::tm* localTime = std::localtime(&now);
+    char buffer[100];
+    std::strftime(buffer, sizeof(buffer), "%d/%b/%Y:%H:%M:%S %z", localTime);
+    return std::string(buffer);
 }
 
 }  // namespace toolbox

--- a/toolbox/access.cpp
+++ b/toolbox/access.cpp
@@ -1,0 +1,102 @@
+// Copyright 2025 Ideal Broccoli
+
+#include "access.hpp"
+
+#include <iostream>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace toolbox {
+
+/*
+ * @brief AccessLog constructor.
+ * @note The reason for not opening the log file in the constructor is to allow
+ *       the user to set the log file name before opening it.
+ */
+logger::AccessLog::AccessLog() : _logFileName("access.log") {
+}
+
+logger::AccessLog::~AccessLog() {
+    if (_logFile.is_open()) {
+        _logFile.close();
+    }
+}
+
+void logger::AccessLog::setLogFile(const std::string& file) {
+    logger::AccessLog& instance = getInstance();
+    if (instance._logFile.is_open()) {
+        instance._logFile.close();
+    }
+    instance._logFileName = file;
+    instance._logFile.open(instance._logFileName.c_str(), std::ios::app);
+    if (!instance._logFile.is_open()) {
+        throw std::runtime_error("Failed to open log file: "
+            + instance._logFileName);
+    }
+    instance._logFile << "[" << instance.getTimeStamp() << "] "
+                      << "Log file opened: " << instance._logFileName
+                      << std::endl;
+}
+
+logger::AccessLog& logger::AccessLog::getInstance() {
+    static AccessLog instance;
+    return instance;
+}
+
+/*
+ * @brief Logs an access request to the log file.
+ * @param remote_addr The remote address of the client.
+ * @param remote_user The remote user (if any).
+ * @param request The HTTP request line.
+ * @param status The HTTP status code.
+ * @param body_bytes_sent The size of the response body in bytes.
+ * @param http_referer The HTTP referer header.
+ * @param http_user_agent The HTTP user agent header.
+ * @throws std::runtime_error if the log file cannot be opened.
+ * @note This function will create the log file if it does not exist.
+ */
+void logger::AccessLog::log(
+    const std::string& remote_addr,
+    const std::string& remote_user,
+    const std::string& request,
+    int status,
+    int body_bytes_sent,
+    const std::string& http_referer,
+    const std::string& http_user_agent
+) {
+    logger::AccessLog& instance = getInstance();
+    if (!instance._logFile.is_open()) {
+        instance._logFile.open(instance._logFileName.c_str(), std::ios::app);
+        if (!instance._logFile.is_open()) {
+            throw std::runtime_error("Failed to open log file: "
+                + instance._logFileName);
+        }
+        instance._logFile << "[" << instance.getTimeStamp() << "] "
+                          << "Log file opened: " << instance._logFileName
+                          << std::endl;
+    }
+
+    instance._logFile << remote_addr << " "
+                      << "- "
+                      << remote_user << " "
+                      << "[" << instance.getTimeStamp() << "] "
+                      << "\"" << request << "\" "
+                      << status << " "
+                      << body_bytes_sent << " "
+                      << "\"" << http_referer << "\" "
+                      << "\"" << http_user_agent << "\""
+                      << std::endl;
+}
+
+std::string logger::AccessLog::getTimeStamp() {
+    std::time_t now = std::time(nullptr);
+    std::tm* tm_now = std::gmtime(&now);
+    std::ostringstream oss;
+    oss << std::put_time(tm_now, "%d/%b/%Y:%H:%M:%S %z");
+    return oss.str();
+}
+
+}  // namespace toolbox

--- a/toolbox/access.hpp
+++ b/toolbox/access.hpp
@@ -1,0 +1,39 @@
+// Copyright 2025 Ideal Broccoli
+
+#pragma once
+
+#include <string>
+#include <fstream>
+
+namespace toolbox {
+
+namespace logger {
+
+class AccessLog {
+ public:
+    static void setLogFile(const std::string& file);
+    static void log(
+        const std::string& remote_addr,
+        const std::string& remote_user,
+        const std::string& request,
+        int status,
+        int body_bytes_sent,
+        const std::string& http_referer,
+        const std::string& http_user_agent);
+
+ private:
+    std::string _logFileName;
+    std::ofstream _logFile;
+
+    static AccessLog& getInstance();
+
+    AccessLog();
+    ~AccessLog();
+    AccessLog(const AccessLog&);
+    AccessLog& operator=(const AccessLog&);
+    std::string getTimeStamp();
+};
+
+}  // namespace logger
+
+}  // namespace toolbox


### PR DESCRIPTION
## 概要

access logクラスを追加

## 変更内容

* access logのクラスを追加しました。
* 実際にresponseクラスの中で呼び出すのは、別issueとします

## 関連Issue

* #74 
* #81 (今後対応予定)

## 影響範囲

* responseクラス

## テスト

* test/toolbox/accesslogディレクトリで、make runとすれば実行できます
* あんまり細かいテストケースもないので、いい感じにmain.cppを変更しながらテストしてもらえればと思います

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。
