### PR TITLE
80 headメソッド2

### DIFF
--- a/src/http/http_namespace.cpp
+++ b/src/http/http_namespace.cpp
@@ -40,12 +40,13 @@ const char* SERVER = "Server";
 const char* SET_COOKIE = "Set-Cookie";
 const char* LOCATION = "Location";
 const char* WWW_AUTHENTICATE = "WWW-Authenticate";
+const char* LAST_MODIFIED = "Last-Modified";
 const char* FIELDS[] = {
 DATE,          CACHE_CONTROL,    CONNECTION,       CONTENT_LENGTH,
 CONTENT_TYPE,  CONTENT_ENCODING, CONTENT_LANGUAGE, TRANSFER_ENCODING,
 HOST,          ACCEPT,           ACCEPT_ENCODING,  ACCEPT_LANGUAGE,
 AUTHORIZATION, USER_AGENT,       COOKIE,           SERVER,
-SET_COOKIE,    LOCATION,         WWW_AUTHENTICATE
+SET_COOKIE,    LOCATION,         WWW_AUTHENTICATE, LAST_MODIFIED
 };
 const std::size_t FIELD_SIZE = sizeof(FIELDS) / sizeof(FIELDS[0]);
 const std::size_t MAX_FIELDLINE_SIZE = 8192;

--- a/src/http/http_namespace.hpp
+++ b/src/http/http_namespace.hpp
@@ -43,6 +43,7 @@ extern const char* SERVER;
 extern const char* SET_COOKIE;
 extern const char* LOCATION;
 extern const char* WWW_AUTHENTICATE;
+extern const char* LAST_MODIFIED;
 extern const char* FIELDS[];
 extern const std::size_t FIELD_SIZE;
 extern const std::size_t MAX_FIELDLINE_SIZE;

--- a/src/http/http_status.hpp
+++ b/src/http/http_status.hpp
@@ -50,7 +50,7 @@ class HttpStatus {
         BAD_GATEWAY = 502,
         SERVICE_UNAVAILABLE = 503,
         GATEWAY_TIMEOUT = 504,
-        HTTP_VERSION_NOT_SUPPORTED = 505
+        HTTP_VERSION_NOT_SUPPORTED = 505,
     };
 
     HttpStatus() : _status(OK) {}

--- a/src/http/response/get_method.cpp
+++ b/src/http/response/get_method.cpp
@@ -36,15 +36,12 @@ void readFile(const std::string& path, std::string& responseBody) {
 
 void appendFileInfoRow(FileInfo& info, std::string& responseBody) {
     std::string size = info.isDir ? "-" : toolbox::to_string(info.size);
-    char timeStr[26];
-    ctime_r(&info.time, timeStr);
-    timeStr[24] = '\0';  // del newline
     std::stringstream ss;
     ss << "<tr>\n"
         << "  <td><a href=\"" << info.path << "\">"
         << info.name << "</a></td>\n"
         << "  <td>" << size << "</td>\n"
-        << "  <td>" << timeStr << "</td>\n"
+        << "  <td>" << info.time << "</td>\n"
         << "</tr>\n";
     responseBody += ss.str();
 }
@@ -97,7 +94,7 @@ void readDirectoryEntries(const std::string& dirPath,
             toolbox::logger::StepMark::error("GetMethod: failed to access");
             throw std::runtime_error("");
         }
-        info.time = st.st_mtime;
+        info.time = getModifiedTime(st);
         info.isDir = S_ISDIR(st.st_mode);
         info.size = st.st_size;
         appendFileInfoRow(info, responseBody);

--- a/src/http/response/get_method.cpp
+++ b/src/http/response/get_method.cpp
@@ -112,12 +112,13 @@ HttpStatus::EHttpStatus handleDirectory(const std::string& path,
 
     if (!indexPath.empty()) {
         struct stat indexSt;
-        status = checkFileAccess(path + indexPath, indexSt);
+        std::string fullPath = joinPath(path, indexPath);
+        status = checkFileAccess(fullPath, indexSt);
         if (status != HttpStatus::OK) {
             return status;
         }
-        response.setBody(readFile(path + indexPath));
-        response.setHeader(fields::CONTENT_TYPE, getContentType(indexPath, extensionMap));
+        response.setBody(readFile(fullPath));
+        response.setHeader(fields::CONTENT_TYPE, getContentType(fullPath, extensionMap));
         response.setHeader(fields::LAST_MODIFIED, getModifiedTime(indexSt));
     }  else if (isAutoindex) {
         response.setBody(processAutoindex(path));

--- a/src/http/response/get_method.cpp
+++ b/src/http/response/get_method.cpp
@@ -17,89 +17,10 @@
 #include "../../../toolbox/stepmark.hpp"
 #include "../../../toolbox/string.hpp"
 #include "../http_namespace.hpp"
+#include "method_utils.hpp"
 #include "get_method.hpp"
 
-namespace {
-// Utility
-struct FileInfo {
-    std::string name;
-    std::string path;
-    time_t time;
-    bool isDir;
-    size_t size;
-};
-
-bool isDirectory(const struct stat& st) {
-    return S_ISDIR(st.st_mode);
-}
-
-bool isRegularFile(const struct stat& st) {
-    return S_ISREG(st.st_mode);
-}
-
-}  // namespace
-
 namespace http {
-std::string joinPath(const std::string& base, const std::string& path) {
-    if (base.empty()) {
-        return path;
-    }
-    if (path.empty()) {
-        return base;
-    }
-    if (base[base.size() - 1] == '/' || path[0] == '/') {
-        return base + path;
-    }
-    return base + "/" + path;
-}
-
-// Extension map functions
-
-void initExtensionMap(ExtensionMap& extensionMap) {
-    extensionMap["html"] = "text/html";
-    extensionMap["htm"] = "text/html";
-    extensionMap["css"] = "text/css";
-    extensionMap["js"] = "application/javascript";
-    extensionMap["json"] = "application/json";
-    extensionMap["txt"] = "text/plain";
-    extensionMap["jpg"] = "image/jpeg";
-    extensionMap["jpeg"] = "image/jpeg";
-    extensionMap["png"] = "image/png";
-    extensionMap["gif"] = "image/gif";
-    extensionMap["svg"] = "image/svg+xml";
-    extensionMap["ico"] = "image/x-icon";
-    extensionMap["pdf"] = "application/pdf";
-    extensionMap["xml"] = "application/xml";
-    extensionMap["zip"] = "application/zip";
-    extensionMap["gz"] = "application/gzip";
-    extensionMap["tar"] = "application/x-tar";
-    extensionMap["mp3"] = "audio/mpeg";
-    extensionMap["mp4"] = "video/mp4";
-    extensionMap["avi"] = "video/x-msvideo";
-    extensionMap["php"] = "application/x-httpd-php";
-    extensionMap["py"] = "text/x-python";
-    extensionMap["c"] = "text/x-c";
-    extensionMap["cpp"] = "text/x-c++";
-    extensionMap["h"] = "text/x-c";
-    extensionMap["hpp"] = "text/x-c++";
-}
-
-std::string getContentType(const std::string& filename,
-                           const ExtensionMap& extensionMap) {
-    size_t pos = filename.find_last_of(".");
-    if (pos == std::string::npos || pos == filename.size()) {
-        return "application/octet-stream";
-    }
-    std::string ext = filename.substr(pos + 1);
-    ExtensionMap::const_iterator it = extensionMap.find(ext);
-    if (it != extensionMap.end()) {
-        return it->second;
-    }
-    return "application/octet-stream";
-}
-
-// File handling functions
-
 void readFile(const std::string& path, std::string& responseBody) {
     std::ifstream file(path.c_str(), std::ios::binary);
     if (!file.is_open()) {
@@ -182,22 +103,6 @@ void readDirectoryEntries(const std::string& dirPath,
         appendFileInfoRow(info, responseBody);
     }
     closedir(dir);
-}
-
-// Main processing functions
-
-HttpStatus::EHttpStatus checkFileAccess(const std::string& path,
-                                        struct stat& st) {
-    if (access(path.c_str(), F_OK) != 0) {
-        return HttpStatus::NOT_FOUND;
-    }
-    if (stat(path.c_str(), &st) != 0) {
-        return HttpStatus::INTERNAL_SERVER_ERROR;
-    }
-    if (!(st.st_mode & S_IRUSR) || access(path.c_str(), R_OK) != 0) {
-        return HttpStatus::FORBIDDEN;
-    }
-    return HttpStatus::OK;
 }
 
 HttpStatus::EHttpStatus handleDirectory(const std::string& path,

--- a/src/http/response/get_method.hpp
+++ b/src/http/response/get_method.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include "../case_insensitive_less.hpp"
+#include "../http_status.hpp"
+
+namespace http {
+
+typedef std::map<std::string, std::string, CaseInsensitiveLess> ExtensionMap;
+
+void initExtensionMap(ExtensionMap& extensionMap);
+HttpStatus::EHttpStatus runGet(const std::string& path,
+                             std::string& responseBody,
+                             const std::string& indexPath,
+                             bool isAutoindex,
+                             std::string& contentType,
+                             ExtensionMap& extensionMap);
+void readDirectoryEntries(const std::string& dirPath,
+                          std::string& responseBody);
+
+}  // namespace http

--- a/src/http/response/get_method.hpp
+++ b/src/http/response/get_method.hpp
@@ -5,15 +5,12 @@
 #include "../case_insensitive_less.hpp"
 #include "../http_status.hpp"
 #include "method_utils.hpp"
+#include "response.hpp"
 
 namespace http {
 HttpStatus::EHttpStatus runGet(const std::string& path,
-                               std::string& responseBody,
                                const std::string& indexPath,
                                bool isAutoindex,
-                               std::string& contentType,
-                             ExtensionMap& extensionMap);
-void readDirectoryEntries(const std::string& dirPath,
-                          std::string& responseBody);
-
+                               Response& response,
+                               ExtensionMap& extensionMap);
 }  // namespace http

--- a/src/http/response/get_method.hpp
+++ b/src/http/response/get_method.hpp
@@ -4,17 +4,14 @@
 #include <map>
 #include "../case_insensitive_less.hpp"
 #include "../http_status.hpp"
+#include "method_utils.hpp"
 
 namespace http {
-
-typedef std::map<std::string, std::string, CaseInsensitiveLess> ExtensionMap;
-
-void initExtensionMap(ExtensionMap& extensionMap);
 HttpStatus::EHttpStatus runGet(const std::string& path,
-                             std::string& responseBody,
-                             const std::string& indexPath,
-                             bool isAutoindex,
-                             std::string& contentType,
+                               std::string& responseBody,
+                               const std::string& indexPath,
+                               bool isAutoindex,
+                               std::string& contentType,
                              ExtensionMap& extensionMap);
 void readDirectoryEntries(const std::string& dirPath,
                           std::string& responseBody);

--- a/src/http/response/get_method.hpp
+++ b/src/http/response/get_method.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <map>
+
 #include "../case_insensitive_less.hpp"
 #include "../http_status.hpp"
 #include "method_utils.hpp"
@@ -11,6 +12,6 @@ namespace http {
 HttpStatus::EHttpStatus runGet(const std::string& path,
                                const std::string& indexPath,
                                bool isAutoindex,
-                               Response& response,
-                               ExtensionMap& extensionMap);
+                               ExtensionMap& extensionMap,
+                               Response& response);
 }  // namespace http

--- a/src/http/response/head_method.cpp
+++ b/src/http/response/head_method.cpp
@@ -15,11 +15,12 @@ HttpStatus::EHttpStatus handleDirectory(const std::string& path,
 
     if (!indexPath.empty()) {
         struct stat indexSt;
-        status = checkFileAccess(path + indexPath, indexSt);
+        std::string fullPath = joinPath(path, indexPath);
+        status = checkFileAccess(fullPath, indexSt);
         if (status != HttpStatus::OK) {
             return status;
         }
-        response.setHeader(fields::CONTENT_TYPE, getContentType(indexPath, extensionMap));
+        response.setHeader(fields::CONTENT_TYPE, getContentType(fullPath, extensionMap));
         response.setHeader(fields::LAST_MODIFIED, getModifiedTime(indexSt));
     }  else if (isAutoindex) {
         response.setHeader(fields::CONTENT_TYPE, "text/html");

--- a/src/http/response/head_method.cpp
+++ b/src/http/response/head_method.cpp
@@ -1,0 +1,72 @@
+#include <string>
+
+#include "../request/http_fields.hpp"
+#include <method_utils.hpp>
+
+namespace http {
+HttpStatus::EHttpStatus handleDirectory(const std::string& path,
+                                        const std::string& indexPath,
+                                        bool isAutoindex,
+                                        ExtensionMap& extensionMap,
+                                        HTTPFields& responseFields) {
+    HttpStatus::EHttpStatus status;
+    if (!indexPath.empty()) {
+        struct stat indexSt;
+        status = checkFileAccess(path + indexPath, indexSt);
+        if (status != HttpStatus::OK) {
+            return status;
+        }
+        responseFields.getFieldValue("Content-Length").push_back(
+            toolbox::to_string(indexSt.st_size));
+        responseFields.getFieldValue("Content-Type").push_back(
+            getContentType(indexPath, extensionMap));
+    }  else if (isAutoindex) {
+        responseFields.getFieldValue("Content-Type").push_back("text/html");
+    }
+    return HttpStatus::OK;
+}
+
+HttpStatus::EHttpStatus handleFile(const std::string& path,
+                                    ExtensionMap& extensionMap,
+                                    HTTPFields& responseFields) {
+    struct stat st;
+    HttpStatus::EHttpStatus status = checkFileAccess(path, st);
+    if (status != HttpStatus::OK) {
+        return status;
+    }
+    responseFields.getFieldValue("Content-Length").push_back(
+        toolbox::to_string(st.st_size));
+    responseFields.getFieldValue("Content-Type").push_back(
+        getContentType(path, extensionMap));
+    return HttpStatus::OK;
+}
+
+HttpStatus::EHttpStatus runHead(const std::string& path,
+                               std::string& responseBody,
+                               const std::string& indexPath,
+                               bool isAutoindex,
+                               ExtensionMap& extensionMap,
+                               HTTPFields& responseFields) {
+    struct stat st;
+
+    HttpStatus::EHttpStatus status = checkFileAccess(path, st);
+    if (status != HttpStatus::OK) {
+        return status;
+    }
+
+    try {
+        if (isDirectory(st)) {
+            status = handleDirectory(path, indexPath, isAutoindex,
+                extensionMap, responseFields);
+        } else if (isRegularFile(st)) {
+            status = handleFile(path, extensionMap, responseFields);
+        } else {
+            status = HttpStatus::INTERNAL_SERVER_ERROR;
+        }
+    } catch (std::exception& e) {
+        status = HttpStatus::INTERNAL_SERVER_ERROR;
+    }
+    return status;
+}
+
+}  // namespace http

--- a/src/http/response/head_method.cpp
+++ b/src/http/response/head_method.cpp
@@ -61,14 +61,14 @@ HttpStatus::EHttpStatus runHead(const std::string& path,
     }
 
     try {
-    if (isDirectory(st)) {
-        status = handleDirectory(path, indexPath, isAutoindex,
-            extensionMap, response);
-    } else if (isRegularFile(st)) {
-        status = handleFile(path, extensionMap, response);
-    } else {
-        status = HttpStatus::INTERNAL_SERVER_ERROR;
-    }
+        if (isDirectory(st)) {
+            status = handleDirectory(path, indexPath, isAutoindex,
+                extensionMap, response);
+        } else if (isRegularFile(st)) {
+            status = handleFile(path, extensionMap, response);
+        } else {
+            status = HttpStatus::INTERNAL_SERVER_ERROR;
+        }
     } catch (const std::exception& e) {
         status = HttpStatus::INTERNAL_SERVER_ERROR;
         toolbox::logger::StepMark::error("runHead: exception "

--- a/src/http/response/head_method.hpp
+++ b/src/http/response/head_method.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include "../case_insensitive_less.hpp"
+#include "../http_status.hpp"
+#include "../request/http_fields.hpp"
+#include "method_utils.hpp"
+#include "response.hpp"
+
+namespace http {
+HttpStatus::EHttpStatus runHead(const std::string& path,
+                               const std::string& indexPath,
+                               bool isAutoindex,
+                               ExtensionMap& extensionMap,
+                               Response& response);
+}  // namespace http

--- a/src/http/response/head_method.hpp
+++ b/src/http/response/head_method.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <map>
+
 #include "../case_insensitive_less.hpp"
 #include "../http_status.hpp"
 #include "../request/http_fields.hpp"

--- a/src/http/response/method_utils.cpp
+++ b/src/http/response/method_utils.cpp
@@ -75,7 +75,7 @@ HttpStatus::EHttpStatus checkFileAccess(const std::string& path,
         return HttpStatus::NOT_FOUND;
     }
     if (stat(path.c_str(), &st) != 0) {
-        return HttpStatus::INTERNAL_SERVER_ERROR;
+        throw std::runtime_error("stat() failed");
     }
     if (!(st.st_mode & S_IRUSR) || access(path.c_str(), R_OK) != 0) {
         return HttpStatus::FORBIDDEN;

--- a/src/http/response/method_utils.cpp
+++ b/src/http/response/method_utils.cpp
@@ -83,4 +83,11 @@ HttpStatus::EHttpStatus checkFileAccess(const std::string& path,
     return HttpStatus::OK;
 }
 
+std::string getModifiedTime(const struct stat& st) {
+    char timeStr[26];
+    ctime_r(&st.st_mtime, timeStr);
+    timeStr[24] = '\0';  // del newline
+    return std::string(timeStr);
+}
+
 }  // namespace http

--- a/src/http/response/method_utils.cpp
+++ b/src/http/response/method_utils.cpp
@@ -1,0 +1,86 @@
+#include <unistd.h>
+
+#include <string>
+
+#include "method_utils.hpp"
+
+namespace http {
+bool isDirectory(const struct stat& st) {
+    return S_ISDIR(st.st_mode);
+}
+
+bool isRegularFile(const struct stat& st) {
+    return S_ISREG(st.st_mode);
+}
+
+std::string joinPath(const std::string& base, const std::string& path) {
+    if (base.empty()) {
+        return path;
+    }
+    if (path.empty()) {
+        return base;
+    }
+    if (base[base.size() - 1] == '/' || path[0] == '/') {
+        return base + path;
+    }
+    return base + "/" + path;
+}
+
+std::string getContentType(const std::string& filename,
+                           const ExtensionMap& extensionMap) {
+    size_t pos = filename.find_last_of(".");
+    if (pos == std::string::npos || pos == filename.size()) {
+        return "application/octet-stream";
+    }
+    std::string ext = filename.substr(pos + 1);
+    ExtensionMap::const_iterator it = extensionMap.find(ext);
+    if (it != extensionMap.end()) {
+        return it->second;
+    }
+    return "application/octet-stream";
+}
+
+void initExtensionMap(ExtensionMap& extensionMap) {
+    extensionMap["html"] = "text/html";
+    extensionMap["htm"] = "text/html";
+    extensionMap["css"] = "text/css";
+    extensionMap["js"] = "application/javascript";
+    extensionMap["json"] = "application/json";
+    extensionMap["txt"] = "text/plain";
+    extensionMap["jpg"] = "image/jpeg";
+    extensionMap["jpeg"] = "image/jpeg";
+    extensionMap["png"] = "image/png";
+    extensionMap["gif"] = "image/gif";
+    extensionMap["svg"] = "image/svg+xml";
+    extensionMap["ico"] = "image/x-icon";
+    extensionMap["pdf"] = "application/pdf";
+    extensionMap["xml"] = "application/xml";
+    extensionMap["zip"] = "application/zip";
+    extensionMap["gz"] = "application/gzip";
+    extensionMap["tar"] = "application/x-tar";
+    extensionMap["mp3"] = "audio/mpeg";
+    extensionMap["mp4"] = "video/mp4";
+    extensionMap["avi"] = "video/x-msvideo";
+    extensionMap["php"] = "application/x-httpd-php";
+    extensionMap["py"] = "text/x-python";
+    extensionMap["c"] = "text/x-c";
+    extensionMap["cpp"] = "text/x-c++";
+    extensionMap["h"] = "text/x-c";
+    extensionMap["hpp"] = "text/x-c++";
+}
+
+HttpStatus::EHttpStatus checkFileAccess(const std::string& path,
+                                        struct stat& st) {
+    if (access(path.c_str(), F_OK) != 0) {
+        return HttpStatus::NOT_FOUND;
+    }
+    if (stat(path.c_str(), &st) != 0) {
+        return HttpStatus::INTERNAL_SERVER_ERROR;
+    }
+    if (!(st.st_mode & S_IRUSR) || access(path.c_str(), R_OK) != 0) {
+        return HttpStatus::FORBIDDEN;
+    }
+    return HttpStatus::OK;
+}
+
+}  // namespace http

--- a/src/http/response/method_utils.cpp
+++ b/src/http/response/method_utils.cpp
@@ -75,7 +75,7 @@ HttpStatus::EHttpStatus checkFileAccess(const std::string& path,
         return HttpStatus::NOT_FOUND;
     }
     if (stat(path.c_str(), &st) != 0) {
-        throw std::runtime_error("stat() failed");
+        return HttpStatus::INTERNAL_SERVER_ERROR;
     }
     if (!(st.st_mode & S_IRUSR) || access(path.c_str(), R_OK) != 0) {
         return HttpStatus::FORBIDDEN;

--- a/src/http/response/method_utils.hpp
+++ b/src/http/response/method_utils.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <sys/stat.h>
+
+#include <string>
+#include <map>
+
+#include "../case_insensitive_less.hpp"
+#include "../http_status.hpp"
+#include "../../../toolbox/stepmark.hpp"
+#include "../http_status.hpp"
+
+namespace http {
+
+typedef std::map<std::string, std::string, CaseInsensitiveLess> ExtensionMap;
+
+struct FileInfo {
+    std::string name;
+    std::string path;
+    time_t time;
+    bool isDir;
+    size_t size;
+};
+
+bool isDirectory(const struct stat& st);
+bool isRegularFile(const struct stat& st);
+std::string joinPath(const std::string& base, const std::string& path);
+std::string getContentType(const std::string& filename,
+                           const ExtensionMap& extensionMap);
+void initExtensionMap(ExtensionMap& extensionMap);
+HttpStatus::EHttpStatus checkFileAccess(const std::string& path,
+                                        struct stat& st);
+}  // namespace http

--- a/src/http/response/method_utils.hpp
+++ b/src/http/response/method_utils.hpp
@@ -17,7 +17,7 @@ typedef std::map<std::string, std::string, CaseInsensitiveLess> ExtensionMap;
 struct FileInfo {
     std::string name;
     std::string path;
-    time_t time;
+    std::string time;
     bool isDir;
     size_t size;
 };
@@ -30,4 +30,5 @@ std::string getContentType(const std::string& filename,
 void initExtensionMap(ExtensionMap& extensionMap);
 HttpStatus::EHttpStatus checkFileAccess(const std::string& path,
                                         struct stat& st);
+std::string getModifiedTime(const struct stat& st);
 }  // namespace http

--- a/src/http/response/method_utils.hpp
+++ b/src/http/response/method_utils.hpp
@@ -8,7 +8,6 @@
 #include "../case_insensitive_less.hpp"
 #include "../http_status.hpp"
 #include "../../../toolbox/stepmark.hpp"
-#include "../http_status.hpp"
 
 namespace http {
 

--- a/test/http/response/method/Makefile
+++ b/test/http/response/method/Makefile
@@ -1,8 +1,11 @@
 NAME = method_test
-SRCS = main.cpp get.cpp ../../../../src/http/response/get_method.cpp \
+SRCS = main.cpp get.cpp head.cpp ../../../../src/http/response/get_method.cpp \
 ../../../../toolbox/stepmark.cpp ../../../../toolbox/string.cpp \
 ../../../../src/http/response/method_utils.cpp \
 ../../../../src/http/response/head_method.cpp \
+../../../../src/http/request/http_fields.cpp \
+../../../../src/http/http_namespace.cpp \
+../../../../src/http/response/response.cpp \
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/test/http/response/method/Makefile
+++ b/test/http/response/method/Makefile
@@ -1,6 +1,9 @@
 NAME = method_test
 SRCS = main.cpp get.cpp ../../../../src/http/response/get_method.cpp \
-../../../../toolbox/stepmark.cpp ../../../../toolbox/string.cpp
+../../../../toolbox/stepmark.cpp ../../../../toolbox/string.cpp \
+../../../../src/http/response/method_utils.cpp \
+../../../../src/http/response/head_method.cpp \
+
 OBJS = $(SRCS:.cpp=.o)
 
 # compiler

--- a/test/http/response/method/get.cpp
+++ b/test/http/response/method/get.cpp
@@ -54,50 +54,50 @@ static void runTests() {
 
     std::cout << "===== get nomal file =====" << std::endl;
     status = http::runGet("./test_dir/test.html", "", false,
-        response, extensionMap);
+        extensionMap, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get nonexistent file =====" << std::endl;
     status = runGet("./test_dir/nonexistent.html", "", false,
-        response, extensionMap);
+        extensionMap, response);
     assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get dir indexfile =====" << std::endl;
     status = runGet("./test_dir/", "index.html", false,
-        response, extensionMap);
+        extensionMap, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get dir autoindex =====" << std::endl;
     status = runGet("./test_dir/", "", true,
-        response, extensionMap);
+        extensionMap, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get no permission =====" << std::endl;
     status = runGet("./test_dir/no_permission.html", "", false,
-        response, extensionMap);
+        extensionMap, response);
     assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get empty dir ====="
         << std::endl;
     status = runGet("./test_dir/empty_dir/", "", true,
-        response, extensionMap);
+        extensionMap, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get empty dir indexfile =====" << std::endl;
     status = runGet("./test_dir/empty_dir/", "index.html",
-        false, response, extensionMap);
+        false, extensionMap, response);
     assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get no permission dir =====" << std::endl;
     status = runGet("./test_dir/no_permission_dir/", "",
-        true, response, extensionMap);
+        true, extensionMap, response);
     assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 }

--- a/test/http/response/method/get.cpp
+++ b/test/http/response/method/get.cpp
@@ -13,7 +13,7 @@
 #include "../../../../src/http/case_insensitive_less.hpp"
 #include "../../../../src/http/response/get_method.hpp"
 
-void setupTestEnvironment() {
+static void setupTestEnvironment() {
     mkdir("./test_dir", 0755);
     mkdir("./test_dir/empty_dir", 0755);
     mkdir("./test_dir/no_permission_dir", 0000);
@@ -32,7 +32,7 @@ void setupTestEnvironment() {
     chmod("./test_dir/no_permission.html", 0000);
 }
 
-void cleanupTestEnvironment() {
+static void cleanupTestEnvironment() {
     chmod("./test_dir/no_permission.html", 0644);
     chmod("./test_dir/no_permission_dir", 0755);
 
@@ -45,7 +45,7 @@ void cleanupTestEnvironment() {
     rmdir("./test_dir");
 }
 
-void runTests() {
+static void runTests() {
     std::string responseBody;
     std::string contentType;
     http::ExtensionMap extensionMap;

--- a/test/http/response/method/get.cpp
+++ b/test/http/response/method/get.cpp
@@ -65,7 +65,7 @@ void runTests() {
     std::cout << "===== get nonexistent file =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = http::runGet("./test_dir/nonexistent.html", responseBody, "", false,
+    status = runGet("./test_dir/nonexistent.html", responseBody, "", false,
         contentType, extensionMap);
     assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
@@ -73,7 +73,7 @@ void runTests() {
     std::cout << "===== get dir indexfile =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = http::runGet("./test_dir/", responseBody, "index.html", false,
+    status = runGet("./test_dir/", responseBody, "index.html", false,
         contentType, extensionMap);
     assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
@@ -83,7 +83,7 @@ void runTests() {
     std::cout << "===== get dir autoindex =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = http::runGet("./test_dir/", responseBody, "", true,
+    status = runGet("./test_dir/", responseBody, "", true,
         contentType, extensionMap);
     assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
@@ -93,7 +93,7 @@ void runTests() {
     std::cout << "===== get no permission =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = http::runGet("./test_dir/no_permission.html", responseBody, "",
+    status = runGet("./test_dir/no_permission.html", responseBody, "",
         false, contentType, extensionMap);
     assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
@@ -102,7 +102,7 @@ void runTests() {
         << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = http::runGet("./test_dir/empty_dir/", responseBody, "", true,
+    status = runGet("./test_dir/empty_dir/", responseBody, "", true,
         contentType, extensionMap);
     assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
@@ -111,7 +111,7 @@ void runTests() {
     std::cout << "===== get empty dir indexfile =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = http::runGet("./test_dir/empty_dir/", responseBody, "index.html",
+    status = runGet("./test_dir/empty_dir/", responseBody, "index.html",
         false, contentType, extensionMap);
     assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
@@ -119,7 +119,7 @@ void runTests() {
     std::cout << "===== get no permission dir =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = http::runGet("./test_dir/no_permission_dir/", responseBody, "",
+    status = runGet("./test_dir/no_permission_dir/", responseBody, "",
         true, contentType, extensionMap);
     assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;

--- a/test/http/response/method/get.cpp
+++ b/test/http/response/method/get.cpp
@@ -11,14 +11,7 @@
 
 #include "../../../../src/http/http_status.hpp"
 #include "../../../../src/http/case_insensitive_less.hpp"
-
-typedef std::map<std::string, std::string, http::CaseInsensitiveLess>
-ExtentionMap;
-
-http::HttpStatus runGet(const std::string& path, std::string& responseBody,
-    const std::string& indexPath, bool isAutoindex, std::string& contentType,
-    ExtentionMap& extensionMap);
-void initExtensionMap(ExtentionMap& extensionMap);
+#include "../../../../src/http/response/get_method.hpp"
 
 void setupTestEnvironment() {
     mkdir("./test_dir", 0755);
@@ -55,16 +48,16 @@ void cleanupTestEnvironment() {
 void runTests() {
     std::string responseBody;
     std::string contentType;
-    ExtentionMap extensionMap;
-    initExtensionMap(extensionMap);
-    http::HttpStatus status;
+    http::ExtensionMap extensionMap;
+    http::initExtensionMap(extensionMap);
+    http::HttpStatus::EHttpStatus status;
 
     std::cout << "===== get nomal file =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/test.html", responseBody, "", false,
+    status = http::runGet("./test_dir/test.html", responseBody, "", false,
         contentType, extensionMap);
-    assert(status == http::OK);
+    assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
     assert(responseBody.find("Test HTML") != std::string::npos);
     std::cout << "OK: " << status << std::endl;
@@ -72,17 +65,17 @@ void runTests() {
     std::cout << "===== get nonexistent file =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/nonexistent.html", responseBody, "", false,
+    status = http::runGet("./test_dir/nonexistent.html", responseBody, "", false,
         contentType, extensionMap);
-    assert(status == http::NOT_FOUND);
+    assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get dir indexfile =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/", responseBody, "index.html", false,
+    status = http::runGet("./test_dir/", responseBody, "index.html", false,
         contentType, extensionMap);
-    assert(status == http::OK);
+    assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
     assert(responseBody.find("Index HTML") != std::string::npos);
     std::cout << "OK: " << status << std::endl;
@@ -90,9 +83,9 @@ void runTests() {
     std::cout << "===== get dir autoindex =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/", responseBody, "", true,
+    status = http::runGet("./test_dir/", responseBody, "", true,
         contentType, extensionMap);
-    assert(status == http::OK);
+    assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
     assert(responseBody.find("Index of") != std::string::npos);
     std::cout << "OK: " << status << std::endl;
@@ -100,35 +93,35 @@ void runTests() {
     std::cout << "===== get no permission =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/no_permission.html", responseBody, "",
+    status = http::runGet("./test_dir/no_permission.html", responseBody, "",
         false, contentType, extensionMap);
-    assert(status == http::FORBIDDEN);
+    assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get empty dir ====="
         << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/empty_dir/", responseBody, "", true,
+    status = http::runGet("./test_dir/empty_dir/", responseBody, "", true,
         contentType, extensionMap);
-    assert(status == http::OK);
+    assert(status == http::HttpStatus::OK);
     assert(contentType == "text/html");
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get empty dir indexfile =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/empty_dir/", responseBody, "index.html",
+    status = http::runGet("./test_dir/empty_dir/", responseBody, "index.html",
         false, contentType, extensionMap);
-    assert(status == http::NOT_FOUND);
+    assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get no permission dir =====" << std::endl;
     responseBody.clear();
     contentType.clear();
-    status = runGet("./test_dir/no_permission_dir/", responseBody, "",
+    status = http::runGet("./test_dir/no_permission_dir/", responseBody, "",
         true, contentType, extensionMap);
-    assert(status == http::FORBIDDEN);
+    assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 }
 

--- a/test/http/response/method/get.cpp
+++ b/test/http/response/method/get.cpp
@@ -12,6 +12,7 @@
 #include "../../../../src/http/http_status.hpp"
 #include "../../../../src/http/case_insensitive_less.hpp"
 #include "../../../../src/http/response/get_method.hpp"
+#include "../../../../src/http/response/response.hpp"
 
 static void setupTestEnvironment() {
     mkdir("./test_dir", 0755);
@@ -46,81 +47,57 @@ static void cleanupTestEnvironment() {
 }
 
 static void runTests() {
-    std::string responseBody;
-    std::string contentType;
     http::ExtensionMap extensionMap;
     http::initExtensionMap(extensionMap);
     http::HttpStatus::EHttpStatus status;
+    http::Response response;
 
     std::cout << "===== get nomal file =====" << std::endl;
-    responseBody.clear();
-    contentType.clear();
-    status = http::runGet("./test_dir/test.html", responseBody, "", false,
-        contentType, extensionMap);
+    status = http::runGet("./test_dir/test.html", "", false,
+        response, extensionMap);
     assert(status == http::HttpStatus::OK);
-    assert(contentType == "text/html");
-    assert(responseBody.find("Test HTML") != std::string::npos);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get nonexistent file =====" << std::endl;
-    responseBody.clear();
-    contentType.clear();
-    status = runGet("./test_dir/nonexistent.html", responseBody, "", false,
-        contentType, extensionMap);
+    status = runGet("./test_dir/nonexistent.html", "", false,
+        response, extensionMap);
     assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get dir indexfile =====" << std::endl;
-    responseBody.clear();
-    contentType.clear();
-    status = runGet("./test_dir/", responseBody, "index.html", false,
-        contentType, extensionMap);
+    status = runGet("./test_dir/", "index.html", false,
+        response, extensionMap);
     assert(status == http::HttpStatus::OK);
-    assert(contentType == "text/html");
-    assert(responseBody.find("Index HTML") != std::string::npos);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get dir autoindex =====" << std::endl;
-    responseBody.clear();
-    contentType.clear();
-    status = runGet("./test_dir/", responseBody, "", true,
-        contentType, extensionMap);
+    status = runGet("./test_dir/", "", true,
+        response, extensionMap);
     assert(status == http::HttpStatus::OK);
-    assert(contentType == "text/html");
-    assert(responseBody.find("Index of") != std::string::npos);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get no permission =====" << std::endl;
-    responseBody.clear();
-    contentType.clear();
-    status = runGet("./test_dir/no_permission.html", responseBody, "",
-        false, contentType, extensionMap);
+    status = runGet("./test_dir/no_permission.html", "", false,
+        response, extensionMap);
     assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get empty dir ====="
         << std::endl;
-    responseBody.clear();
-    contentType.clear();
-    status = runGet("./test_dir/empty_dir/", responseBody, "", true,
-        contentType, extensionMap);
+    status = runGet("./test_dir/empty_dir/", "", true,
+        response, extensionMap);
     assert(status == http::HttpStatus::OK);
-    assert(contentType == "text/html");
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get empty dir indexfile =====" << std::endl;
-    responseBody.clear();
-    contentType.clear();
-    status = runGet("./test_dir/empty_dir/", responseBody, "index.html",
-        false, contentType, extensionMap);
+    status = runGet("./test_dir/empty_dir/", "index.html",
+        false, response, extensionMap);
     assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get no permission dir =====" << std::endl;
-    responseBody.clear();
-    contentType.clear();
-    status = runGet("./test_dir/no_permission_dir/", responseBody, "",
-        true, contentType, extensionMap);
+    status = runGet("./test_dir/no_permission_dir/", "",
+        true, response, extensionMap);
     assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 }

--- a/test/http/response/method/head.cpp
+++ b/test/http/response/method/head.cpp
@@ -1,0 +1,117 @@
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <cstdio>
+#include <fstream>
+#include <map>
+
+#include "../../../../src/http/http_status.hpp"
+#include "../../../../src/http/case_insensitive_less.hpp"
+#include "../../../../src/http/request/http_fields.hpp"
+#include "../../../../src/http/response/method_utils.hpp"
+#include "../../../../src/http/response/head_method.hpp"
+#include "../../../../src/http/response/response.hpp"
+#include "../../../../src/http/http_namespace.hpp"
+
+static void setupTestEnvironment() {
+    mkdir("./test_dir", 0755);
+    mkdir("./test_dir/empty_dir", 0755);
+    mkdir("./test_dir/no_permission_dir", 0000);
+
+    std::ofstream test_file("./test_dir/test.html");
+    test_file << "<html><body><h1>Test HTML</h1></body></html>";
+    test_file.close();
+
+    std::ofstream index_file("./test_dir/index.html");
+    index_file << "<html><body><h1>Index HTML</h1></body></html>";
+    index_file.close();
+
+    std::ofstream no_perm_file("./test_dir/no_permission.html");
+    no_perm_file << "<html><body><h1>No Permission</h1></body></html>";
+    no_perm_file.close();
+    chmod("./test_dir/no_permission.html", 0000);
+}
+
+static void cleanupTestEnvironment() {
+    chmod("./test_dir/no_permission.html", 0644);
+    chmod("./test_dir/no_permission_dir", 0755);
+
+    remove("./test_dir/test.html");
+    remove("./test_dir/index.html");
+    remove("./test_dir/no_permission.html");
+
+    rmdir("./test_dir/empty_dir");
+    rmdir("./test_dir/no_permission_dir");
+    rmdir("./test_dir");
+}
+
+static void runTests() {
+    http::ExtensionMap extensionMap;
+    http::HttpStatus::EHttpStatus status;
+    http::Response response;
+
+    std::cout << "===== head normal file (modified time) =====" << std::endl;
+    status = http::runHead("./test_dir/test.html", "", false,
+        extensionMap, response);
+    assert(status == http::HttpStatus::OK);
+    std::cout << "OK: " << status << std::endl;
+
+    std::cout << "===== head nonexistent file =====" << std::endl;
+    status = http::runHead("./test_dir/nonexistent.html", "", false,
+        extensionMap, response);
+    assert(status == http::HttpStatus::NOT_FOUND);
+    std::cout << "OK: " << status << std::endl;
+
+    std::cout << "===== head dir indexfile (modified time) =====" << std::endl;
+    status = http::runHead("./test_dir/", "index.html", false,
+        extensionMap, response);
+    assert(status == http::HttpStatus::OK);
+    std::cout << "OK: " << status << std::endl;
+
+    std::cout << "===== head dir autoindex =====" << std::endl;
+    status = http::runHead("./test_dir/", "", true,
+        extensionMap, response);
+    assert(status == http::HttpStatus::OK);
+    std::cout << "OK: " << status << std::endl;
+
+    std::cout << "===== head no permission =====" << std::endl;
+    status = http::runHead("./test_dir/no_permission.html", "",
+        false, extensionMap, response);
+    assert(status == http::HttpStatus::FORBIDDEN);
+    std::cout << "OK: " << status << std::endl;
+
+    std::cout << "===== head empty dir ====="
+        << std::endl;
+    status = http::runHead("./test_dir/empty_dir/", "",
+        true, extensionMap, response);
+    assert(status == http::HttpStatus::OK);
+    std::cout << "OK: " << status << std::endl;
+
+    std::cout << "===== head empty dir indexfile =====" << std::endl;
+    status = http::runHead("./test_dir/empty_dir/", "index.html",
+        false, extensionMap, response);
+    assert(status == http::HttpStatus::NOT_FOUND);
+    std::cout << "OK: " << status << std::endl;
+
+    std::cout << "===== head no permission dir =====" << std::endl;
+    status = http::runHead("./test_dir/no_permission_dir/", "",
+        true, extensionMap, response);
+    assert(status == http::HttpStatus::FORBIDDEN);
+    std::cout << "OK: " << status << std::endl;
+}
+
+void head_test() {
+    try {
+        setupTestEnvironment();
+        runTests();
+        cleanupTestEnvironment();
+        std::cout << "OK" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << "FAILED" << e.what() << std::endl;
+        cleanupTestEnvironment();
+    }
+}

--- a/test/http/response/method/head.cpp
+++ b/test/http/response/method/head.cpp
@@ -51,6 +51,7 @@ static void cleanupTestEnvironment() {
 
 static void runTests() {
     http::ExtensionMap extensionMap;
+    http::initExtensionMap(extensionMap);
     http::HttpStatus::EHttpStatus status;
     http::Response response;
 

--- a/test/http/response/method/main.cpp
+++ b/test/http/response/method/main.cpp
@@ -1,6 +1,8 @@
 void get_test();
+void head_test();
 
 int main() {
     get_test();
+    head_test();
     return 0;
 }


### PR DESCRIPTION
## 概要
headメソッドの追加
getメソッドの修正

## 変更内容
### 共通
* 関数の引数にResponseクラスを持ち、設定可能なフィールド、ボディを追加した
* getのテストでフィールドの値が正しいことは確認済みのため今回のテストケースではステータスのみの確認とし、それぞれの値はResponseクラスのフィールドに直接入れることにしました。
* 汎用関数をmethod_utilsにまとめました
### head
* 基本的にはbodyを生成しないGET
### get
* #24 からの内部での処理概要は変更ありません。

## 関連Issue

* #79 
* #68 

## 影響範囲

* src/http/response
* src/http/http_namespace
* test/http/response/method

## テスト

* test/http/response/method make GET、HEADともに同様のテストが動くようになっています。

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。




<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | HTTPレスポンスに`LAST_MODIFIED`フィールドが追加されました。 |
| New Feature | HTTP GETおよびHEADメソッドの処理機能が追加されました。 |
| Test | GETおよびHEADメソッドのテストケースが追加され、テスト環境のセットアップとクリーンアップが導入されました。 |
| Refactor | HTTPメソッドのユーティリティ関数が整理され、共通化されました。 |

このプルリクエストでは、新しいHTTPメソッドの実装とテストがしっかりと行われており、コードのモジュール性と保守性が向上しています。特に、ユーティリティ関数の共通化によって再利用性が高まり、今後の拡張にも対応しやすくなっています。素晴らしい仕事です！
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->