### PR TITLE
parser状態推移

### DIFF
--- a/src/http/cgi/cgi_response_parser.cpp
+++ b/src/http/cgi/cgi_response_parser.cpp
@@ -4,9 +4,6 @@
 
 namespace http {
 BaseParser::ParseStatus CgiResponseParser::processFieldLine() {
-    if (getBuf()->find(symbols::CRLF) == std::string::npos) {
-        return P_NEED_MORE_DATA;
-    }
     while (true) {
         LineEndInfo lineEnd = findLineEnd();
         if (lineEnd.pos == std::string::npos) {
@@ -67,9 +64,9 @@ CgiResponseParser::LineEndInfo CgiResponseParser::findLineEnd() {
         return LineEndInfo(std::string::npos, 0);
     }
     if (crlfPos < lfPos) {
-        return LineEndInfo(crlfPos, 2);  // symbols::CRLF.size()
+        return LineEndInfo(crlfPos, symbols::CRLF_SIZE);
     }
-    return LineEndInfo(lfPos, 1);  // symbols::LF.size()
+    return LineEndInfo(lfPos, symbols::LF_SIZE);
 }
 
 bool CgiResponseParser::isValidStatusMessage(int code,

--- a/src/http/http_namespace.cpp
+++ b/src/http/http_namespace.cpp
@@ -66,6 +66,8 @@ const char* PERCENT = "%";
 const char* COLON = ":";
 const char* COMMA = ",";
 const char* COMMASP = ", ";
+const std::size_t LF_SIZE = 1;
+const std::size_t CRLF_SIZE = 2;
 }  // namespace symbols
 
 }  // namespace http

--- a/src/http/http_namespace.hpp
+++ b/src/http/http_namespace.hpp
@@ -63,6 +63,8 @@ extern const char* PERCENT;
 extern const char* COLON;
 extern const char* COMMA;
 extern const char* COMMASP;
+extern const std::size_t LF_SIZE;
+extern const std::size_t CRLF_SIZE;
 }  // namespace symbols
 
 }  // namespace http

--- a/src/http/parsing/base_parser.cpp
+++ b/src/http/parsing/base_parser.cpp
@@ -15,6 +15,7 @@ BaseParser::ParseStatus BaseParser::run(const std::string& buf) {
         return _parseStatus;
     }
     _buf += buf;
+    _parseStatus = P_IN_PROGRESS;
     try {
         while (_parseStatus == P_IN_PROGRESS) {
             switch (_validatePos) {
@@ -53,9 +54,9 @@ std::size_t BaseParser::findNewLinePos(std::string& buffer) {
 std::size_t BaseParser::getLineEndLen
 (std::string& line, std::size_t lineEndPos) {
     if (line.find(symbols::CRLF) == lineEndPos) {
-        return 2;
+        return symbols::CRLF_SIZE;
     }
-    return 1;
+    return symbols::LF_SIZE;
 }
 
 }  // namespace http

--- a/src/http/request/request_parser.cpp
+++ b/src/http/request/request_parser.cpp
@@ -297,9 +297,6 @@ BaseParser::ParseStatus RequestParser::processBody() {
         parseChunkedEncoding();
         return P_COMPLETED;
     }
-
-    std::cout << "RequestParser: processBody" << std::endl;
-    std::cout << getBuf()->c_str()<< std::endl;
     if (!_request.body.contentLength) {
         std::vector<std::string>& contentLen =
             _request.fields.getFieldValue(fields::CONTENT_LENGTH);

--- a/test/http/cgi/Makefile
+++ b/test/http/cgi/Makefile
@@ -3,13 +3,16 @@ NAME = cgi_test.out
 SRC_DIRS = ../../../src
 TOOLBOX_DIR = ../../../toolbox
 
-TEST_SRCS = $(filter-out $(SRC_DIRS)/core/main.cpp, $(wildcard $(SRC_DIRS)/*/*.cpp)\
-			$(wildcard $(SRC_DIRS)/*/*/*.cpp) $(wildcard $(TOOLBOX_DIR)/*.cpp))\
+
+TEST_SRCS = $(wildcard $(SRC_DIRS)/http/*.cpp)\
+			$(wildcard $(SRC_DIRS)/http/request/*.cpp)\
+			$(wildcard $(SRC_DIRS)/http/parsing/*.cpp)\
+			$(wildcard $(SRC_DIRS)/http/cgi/*.cpp)\
+			../../../src/http/response/response.cpp\
+			$(wildcard $(TOOLBOX_DIR)/*.cpp)\
 			$(wildcard *.cpp) \
             $(wildcard http/*.cpp) \
-            $(wildcard http/request/*.cpp) \
-			$(wildcard http/cgi/*.cpp)\
-
+	
 CXX = c++
 CXXFLAGS = -Wall -Wextra -Werror -std=c++98 -I..
 

--- a/test/http/cgi/cgi_buf_size_test.cpp
+++ b/test/http/cgi/cgi_buf_size_test.cpp
@@ -1,0 +1,68 @@
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <cassert>
+#include "../../../src/http/cgi/cgi_response_parser.hpp"
+#include "../../../src/http/cgi/cgi_response.hpp"
+#include "../../../src/http/request/http_fields.hpp"
+
+std::string statusToString(http::BaseParser::ParseStatus status);
+
+void testCgiBufSize() {
+    http::CgiResponseParser parser;
+    std::string request =
+        "Content-type: text/html\r\n"
+        "Content-Length: 13\n"
+        "\n"
+        "Hello, World!";
+    const size_t BUFFER_SIZE = 10;
+
+    size_t pos = 0;
+    http::BaseParser::ParseStatus status = http::BaseParser::P_IN_PROGRESS;
+
+    std::cout << "===== テスト開始 =====\n";
+
+    while (pos < request.size() && status != http::BaseParser::P_ERROR) {
+        size_t chunk_size = std::min(BUFFER_SIZE, request.size() - pos);
+        std::string chunk = request.substr(pos, chunk_size);
+        pos += chunk_size;
+
+        status = parser.run(chunk);
+
+        // std::cout << "チャンク処理: [" << chunk << "]\n";
+        // std::cout << "ステータス: " << statusToString(status) << "\n";
+    }
+    if (status == http::BaseParser::P_NEED_MORE_DATA) {
+        std::cout << "パース完了:\n";
+        std::cout << "  content-type: " << parser.get().fields.getFieldValue(http::fields::CONTENT_TYPE).front() << "\n";
+        std::cout << "  content-length: " << parser.get().fields.getFieldValue(http::fields::CONTENT_LENGTH).front() << "\n";
+        std::cout << "  ボディ: " << parser.get().body << "\n";
+        assert(parser.get().fields.getFieldValue(http::fields::CONTENT_TYPE).front() == "text/html");
+        assert(parser.get().fields.getFieldValue(http::fields::CONTENT_LENGTH).front() == "13");
+        assert(parser.get().body == "Hello, World!");
+    } else if (status == http::BaseParser::P_ERROR) {
+        std::cout << "エラー発生: HTTPステータス " 
+                    << parser.get().httpStatus.get() << "\n";
+    }
+    std::cout << "===== テスト終了 =====\n";
+    if (status == http::BaseParser::P_NEED_MORE_DATA) {
+        std::cout << "テスト成功: リクエストが正しく解析されました\n";
+    } else {
+        std::cout << "テスト失敗: リクエストの解析が完了しませんでした\n";
+    }
+}
+
+std::string statusToString(http::BaseParser::ParseStatus status) {
+    switch (status) {
+        case http::BaseParser::P_IN_PROGRESS:
+            return "処理中";
+        case http::BaseParser::P_NEED_MORE_DATA:
+            return "データ不足";
+        case http::BaseParser::P_COMPLETED:
+            return "完了";
+        case http::BaseParser::P_ERROR:
+            return "エラー";
+        default:
+            return "不明";
+    }
+}

--- a/test/http/cgi/main.cpp
+++ b/test/http/cgi/main.cpp
@@ -2,11 +2,13 @@
 #include "cgi_response_test.hpp"
 
 void requestLineTest();
+void testCgiBufSize();
 
 int main(void) {
     toolbox::logger::StepMark::setLogFile("cgi_test.log");
     toolbox::logger::StepMark::setLevel(toolbox::logger::DEBUG);
     requestLineTest();
+    testCgiBufSize();
 
     return 0;
 }

--- a/test/http/request/Makefile
+++ b/test/http/request/Makefile
@@ -3,8 +3,10 @@ NAME = test.out
 SRC_DIRS = ../../../src
 TOOLBOX_DIR = ../../../toolbox
 
-TEST_SRCS = $(filter-out $(SRC_DIRS)/core/main.cpp, $(wildcard $(SRC_DIRS)/*/*.cpp)\
-			$(wildcard $(SRC_DIRS)/*/*/*.cpp) $(wildcard $(TOOLBOX_DIR)/*.cpp))\
+TEST_SRCS = $(wildcard $(SRC_DIRS)/http/*.cpp)\
+			$(wildcard $(SRC_DIRS)/http/request/*.cpp)\
+			$(wildcard $(SRC_DIRS)/http/parsing/*.cpp)\
+			$(wildcard $(TOOLBOX_DIR)/*.cpp)\
 			$(wildcard *.cpp) \
             $(wildcard http/*.cpp) \
             $(wildcard http/request/*.cpp) \

--- a/test/http/request/request_buf_size_test.cpp
+++ b/test/http/request/request_buf_size_test.cpp
@@ -28,8 +28,8 @@ void testRequestParser() {
 
         status = parser.run(chunk);
 
-        // std::cout << "チャンク処理: [" << chunk << "]\n";
-        // std::cout << "ステータス: " << statusToString(status) << "\n";
+        std::cout << "チャンク処理: [" << chunk << "]\n";
+        std::cout << "ステータス: " << statusToString(status) << "\n";
 
         if (status == http::BaseParser::P_COMPLETED) {
             http::HTTPRequest& req = parser.get();

--- a/test/http/request/request_buf_size_test.cpp
+++ b/test/http/request/request_buf_size_test.cpp
@@ -28,8 +28,8 @@ void testRequestParser() {
 
         status = parser.run(chunk);
 
-        std::cout << "チャンク処理: [" << chunk << "]\n";
-        std::cout << "ステータス: " << statusToString(status) << "\n";
+        // std::cout << "チャンク処理: [" << chunk << "]\n";
+        // std::cout << "ステータス: " << statusToString(status) << "\n";
 
         if (status == http::BaseParser::P_COMPLETED) {
             http::HTTPRequest& req = parser.get();


### PR DESCRIPTION
~

## 概要
parserが正しく状態推移できるように修正
## 変更内容

* baseParserのメインループに入る前にparseStatusを毎回初期化することで複数回関数が呼ばれることを許容した
* requestFieldParserが終了する際にCRLF分のbufを消してからBodyの処理に入るように変更した
* requestFieldParserでfindが呼ばれる回数を減らした

## 関連Issue

* #69 #60

## 影響範囲

* src/http/request
* src/http/cgi
* test/http/request
* test/http/cgi

## テスト

* test/http/request
* test/http/cgi
両方でテストを実行
リクエスト、レスポンスが複数回に分かれる場合を再現(10byteずつ送信)し、正しく状態推移できている場合は、テストが正常に終了します。
cigのテストケースがP_NEED_MORE_DATAで終了しているのは、CGIレスポンスははEOFが送信されるまで全て読み込む必要がありますが、パーサー側では検知することができないため、この関数を呼ぶ親側でEOFの場合はパースを終了する想定です。

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | HTTPパーサーの状態管理と改行処理が改善され、コードの可読性と正確性が向上しました。 |
| Test | テスト範囲が拡大され、CGIバッファサイズのテストが追加されました。 |
| Chore | テストソースファイルの選択方法が改善され、すべての関連ファイルをカバーするようになりました。 |

このプルリクエストでは、HTTPパーサーのロジックが洗練され、テストの包括性が強化されています。特に、状態管理の改善とテスト範囲の拡大は、システムの信頼性を高める重要なステップです。素晴らしい仕事です！
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->