### PR TITLE
27 deleteメソッド

### DIFF
--- a/src/http/response/delete_method.cpp
+++ b/src/http/response/delete_method.cpp
@@ -1,0 +1,10 @@
+#include "delete_method.hpp"
+
+namespace http {
+
+HttpStatus::EHttpStatus runDelete(const std::string& path, Response& response) {
+    HttpStatus::EHttpStatus status;
+    return status;
+}
+
+}  // namespace http

--- a/src/http/response/delete_method.cpp
+++ b/src/http/response/delete_method.cpp
@@ -1,10 +1,50 @@
-#include "delete_method.hpp"
+#include <string>
 
+#include "delete_method.hpp"
 namespace http {
 
-HttpStatus::EHttpStatus runDelete(const std::string& path, Response& response) {
-    HttpStatus::EHttpStatus status;
-    return status;
+namespace {
+HttpStatus::EHttpStatus handleFile(const std::string& path) {
+    if (std::remove(path.c_str()) != 0) {
+        toolbox::logger::StepMark::error("runDelete: remove fail "
+            + path + " " + toolbox::to_string(HttpStatus::INTERNAL_SERVER_ERROR)
+            + " " + std::strerror(errno));
+        return HttpStatus::INTERNAL_SERVER_ERROR;
+    }
+    toolbox::logger::StepMark::info("runDelete: remove success "
+        + path + " " + toolbox::to_string(HttpStatus::NO_CONTENT));
+    return HttpStatus::NO_CONTENT;
+}
+}  // namespace
+
+void runDelete(const std::string& path, Response& response) {
+    struct stat st;
+
+    HttpStatus::EHttpStatus status = checkFileAccess(path, st);
+    if (status != HttpStatus::OK) {
+        toolbox::logger::StepMark::error("runDelete: checkFileAccess fail "
+            + path + " " + toolbox::to_string(status));
+        response.setStatus(status);
+    } else {
+        try {
+            if (isDirectory(st)) {
+                toolbox::logger::StepMark::error("runDelete: isDirectory "
+                    + path + " " + toolbox::to_string(HttpStatus::FORBIDDEN));
+                response.setStatus(HttpStatus::FORBIDDEN);
+            } else if (isRegularFile(st)) {
+                response.setStatus(handleFile(path));
+            } else {
+                toolbox::logger::StepMark::error("runDelete: not a regularfile "
+                    + path + " " + toolbox::to_string(HttpStatus::INTERNAL_SERVER_ERROR));
+                response.setStatus(HttpStatus::INTERNAL_SERVER_ERROR);
+            }
+        } catch (const std::exception& e) {
+            response.setStatus(HttpStatus::INTERNAL_SERVER_ERROR);
+            toolbox::logger::StepMark::error("runDelete: exception "
+                + std::string(e.what()) + " "
+                + toolbox::to_string(HttpStatus::INTERNAL_SERVER_ERROR));
+        }
+    }
 }
 
 }  // namespace http

--- a/src/http/response/delete_method.cpp
+++ b/src/http/response/delete_method.cpp
@@ -7,8 +7,7 @@ namespace {
 HttpStatus::EHttpStatus handleFile(const std::string& path) {
     if (std::remove(path.c_str()) != 0) {
         toolbox::logger::StepMark::error("runDelete: remove fail "
-            + path + " " + toolbox::to_string(HttpStatus::INTERNAL_SERVER_ERROR)
-            + " " + std::strerror(errno));
+            + path + " " + toolbox::to_string(HttpStatus::INTERNAL_SERVER_ERROR));
         return HttpStatus::INTERNAL_SERVER_ERROR;
     }
     toolbox::logger::StepMark::info("runDelete: remove success "

--- a/src/http/response/delete_method.hpp
+++ b/src/http/response/delete_method.hpp
@@ -1,8 +1,12 @@
+#include <string>
+
+#include <cstring>
+
 #include "../http_status.hpp"
 #include "../http_namespace.hpp"
 #include "response.hpp"
 #include "method_utils.hpp"
 
 namespace http {
-void runDelete(std::string& path, Response& response);
+void runDelete(const std::string& path, Response& response);
 }

--- a/src/http/response/delete_method.hpp
+++ b/src/http/response/delete_method.hpp
@@ -1,0 +1,8 @@
+#include "../http_status.hpp"
+#include "../http_namespace.hpp"
+#include "response.hpp"
+#include "method_utils.hpp"
+
+namespace http {
+void runDelete(std::string& path, Response& response);
+}

--- a/src/http/response/method_utils.hpp
+++ b/src/http/response/method_utils.hpp
@@ -8,6 +8,7 @@
 #include "../case_insensitive_less.hpp"
 #include "../http_status.hpp"
 #include "../../../toolbox/stepmark.hpp"
+#include "../../../toolbox/string.hpp"
 
 namespace http {
 

--- a/test/http/response/method/Makefile
+++ b/test/http/response/method/Makefile
@@ -1,11 +1,14 @@
 NAME = method_test
-SRCS = main.cpp get.cpp head.cpp ../../../../src/http/response/get_method.cpp \
-../../../../toolbox/stepmark.cpp ../../../../toolbox/string.cpp \
+SRCS = main.cpp get.cpp head.cpp delete.cpp \
+../../../../src/http/response/get_method.cpp \
+../../../../toolbox/stepmark.cpp \
+ ../../../../toolbox/string.cpp \
 ../../../../src/http/response/method_utils.cpp \
 ../../../../src/http/response/head_method.cpp \
 ../../../../src/http/request/http_fields.cpp \
 ../../../../src/http/http_namespace.cpp \
 ../../../../src/http/response/response.cpp \
+../../../../src/http/response/delete_method.cpp \
 
 OBJS = $(SRCS:.cpp=.o)
 
@@ -24,6 +27,7 @@ clean:
 
 fclean: clean
 	$(RM) $(NAME)
+	$(RM) stepmark.log
 
 re: fclean all
 

--- a/test/http/response/method/delete.cpp
+++ b/test/http/response/method/delete.cpp
@@ -20,7 +20,6 @@
 
 static void setupTestEnvironment() {
     mkdir("./test_dir", 0755);
-    mkdir("./test_dir/no_permission_dir", 0000);
 
     std::ofstream test_file("./test_dir/test.html");
     test_file << "<html><body><h1>Test HTML</h1></body></html>";
@@ -39,13 +38,11 @@ static void setupTestEnvironment() {
 
 static void cleanupTestEnvironment() {
     chmod("./test_dir/no_permission.html", 0644);
-    chmod("./test_dir/no_permission_dir", 0755);
 
     remove("./test_dir/test.html");
     remove("./test_dir/index.html");
     remove("./test_dir/no_permission.html");
 
-    rmdir("./test_dir/no_permission_dir");
     rmdir("./test_dir");
 }
 

--- a/test/http/response/method/delete.cpp
+++ b/test/http/response/method/delete.cpp
@@ -1,0 +1,92 @@
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <cstdio>
+#include <fstream>
+#include <map>
+
+#include "../../../../src/http/http_status.hpp"
+#include "../../../../src/http/case_insensitive_less.hpp"
+#include "../../../../src/http/request/http_fields.hpp"
+#include "../../../../src/http/response/method_utils.hpp"
+#include "../../../../src/http/response/delete_method.hpp"
+#include "../../../../src/http/response/response.hpp"
+#include "../../../../src/http/http_namespace.hpp"
+
+
+static void setupTestEnvironment() {
+    mkdir("./test_dir", 0755);
+    mkdir("./test_dir/no_permission_dir", 0000);
+
+    std::ofstream test_file("./test_dir/test.html");
+    test_file << "<html><body><h1>Test HTML</h1></body></html>";
+    test_file.close();
+
+    std::ofstream index_file("./test_dir/index.html");
+    index_file << "<html><body><h1>Index HTML</h1></body></html>";
+    index_file.close();
+
+    std::ofstream no_perm_file("./test_dir/no_permission.html");
+    no_perm_file << "<html><body><h1>No Permission</h1></body></html>";
+    no_perm_file.close();
+
+    chmod("./test_dir/no_permission.html", 0000);
+}
+
+static void cleanupTestEnvironment() {
+    chmod("./test_dir/no_permission.html", 0644);
+    chmod("./test_dir/no_permission_dir", 0755);
+
+    remove("./test_dir/test.html");
+    remove("./test_dir/index.html");
+    remove("./test_dir/no_permission.html");
+
+    rmdir("./test_dir/no_permission_dir");
+    rmdir("./test_dir");
+}
+
+static void runTests() {
+    http::ExtensionMap extensionMap;
+    http::initExtensionMap(extensionMap);
+    http::Response response;
+
+    std::string path = "./test_dir/test.html";
+    toolbox::logger::StepMark::info("===== delete normal file =====");
+    toolbox::logger::StepMark::info("except status: " +
+        toolbox::to_string(http::HttpStatus::NO_CONTENT));
+    http::runDelete(path, response);
+
+    path = "./test_dir/nonexistent.html";
+    toolbox::logger::StepMark::info("===== delete nonexistent file =====");
+    toolbox::logger::StepMark::info("except status: " +
+        toolbox::to_string(http::HttpStatus::NOT_FOUND));
+    http::runDelete(path, response);
+
+    path = "./test_dir/no_permission.html";
+    toolbox::logger::StepMark::info("===== delete no_permission file =====");
+    toolbox::logger::StepMark::info("except status: " +
+        toolbox::to_string(http::HttpStatus::FORBIDDEN));
+    http::runDelete(path, response);
+
+    path = "./test_dir";
+    toolbox::logger::StepMark::info("===== delete dir =====");
+    toolbox::logger::StepMark::info("except status: " +
+        toolbox::to_string(http::HttpStatus::FORBIDDEN));
+    http::runDelete(path, response);
+}
+
+void delete_test() {
+    try {
+        setupTestEnvironment();
+        runTests();
+        cleanupTestEnvironment();
+        std::cout << "OK" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << "FAILED" << e.what() << std::endl;
+        cleanupTestEnvironment();
+    }
+}

--- a/test/http/response/method/main.cpp
+++ b/test/http/response/method/main.cpp
@@ -1,8 +1,15 @@
+#include <iostream>
+
 void get_test();
 void head_test();
+void delete_test();
 
 int main() {
+    std::cout << "----------------GET----------------" << std::endl;
     get_test();
+    std::cout << "----------------HEAD----------------" << std::endl;
     head_test();
+    std::cout << "----------------DELETE----------------" << std::endl;
+    delete_test();
     return 0;
 }


### PR DESCRIPTION
## 概要
deleteメソッドの実装
## 変更内容

* std::removeを使用したファイル削除
* ディレクトリの削除については対応していません(ファイルアップロードが要件のため)

## 関連Issue

* #83 

## 影響範囲

* src/http/response/delete_method.c/hpp
* test/http/response/method/delete.cpp

## テスト

* test/http/response/method/ make
* responseクラスの関数を使用し、それぞれのステータスが設定された際にログを出すようにしました。
* deleteのテスト結果はstepmark.logを参照してください。

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | HTTP DELETEリクエストを処理するための`runDelete`メソッドが追加されました。 |
| Test | ファイル削除機能のテストケースが追加され、様々なシナリオでの動作確認が可能になりました。 |
| Chore | テスト用Makefileに`delete_method.cpp`が追加され、クリーンアッププロセスが改善されました。 |

このプルリクエストは、HTTP DELETEメソッドの実装とその包括的なテストを通じて、コードベースの機能性と信頼性を大幅に向上させています。特に、エラーハンドリングとログ出力の適切な実装が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->