### PR TITLE
87-設定ファイルクラスのシングルトン化

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -2,16 +2,46 @@
 
 #include "config.hpp"
 #include "config_http.hpp"
+#include "config_parser.hpp"
+#include "config_util.hpp"
 
 #include "../../toolbox/shared.hpp"
+#include "../../toolbox/stepmark.hpp"
 
 namespace config {
 
 Config::Config() :
-_token_count(0) {
+_tokenCount(0) {
 }
 
 Config::~Config() {
+}
+
+Config& Config::getInstance() {
+    static Config instance;
+    return instance;
+}
+
+/**
+ * @brief Loads server configuration from the specified file
+ * 
+ * This static method parses the given configuration file using ConfigParser
+ * and applies the resulting settings to the singleton Config instance.
+ * If parsing fails, a ConfigException is thrown with an appropriate error message.
+ * 
+ * @param configFile Path to the configuration file to be loaded
+ * @throws ConfigException If the configuration file cannot be parsed successfully
+ */
+void Config::loadConfig(const std::string& configFile) {
+    Config& instance = getInstance();
+    ConfigParser parser;
+    toolbox::SharedPtr<Config> configPtr = parser.parseFile(configFile);
+    if (!configPtr) {
+        throwConfigError("Failed to parse configuration file: " + configFile);
+    }
+    instance._httpConfig = configPtr->getHttpConfig();
+    instance._tokenCount = configPtr->getTokenCount();
+    toolbox::logger::StepMark::info("Configuration loaded successfully");
 }
 
 ConfigException::ConfigException(const std::string& message):

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -35,12 +35,12 @@ Config& Config::getInstance() {
 void Config::loadConfig(const std::string& configFile) {
     Config& instance = getInstance();
     ConfigParser parser;
-    toolbox::SharedPtr<Config> configPtr = parser.parseFile(configFile);
-    if (!configPtr) {
+    toolbox::SharedPtr<HttpConfig> httpConfig = parser.parseFile(configFile);
+    if (!httpConfig) {
         throwConfigError("Failed to parse configuration file: " + configFile);
     }
-    instance._httpConfig = configPtr->getHttpConfig();
-    instance._tokenCount = configPtr->getTokenCount();
+    instance._httpConfig = httpConfig;
+    instance._tokenCount = parser.getTokenCount();
     toolbox::logger::StepMark::info("Configuration loaded successfully");
 }
 

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -33,10 +33,7 @@ namespace config {
  *   config::Config::loadConfig("server.conf");
  *   
  *   // Get singleton instance
- *   const config::Config& config = config::Config::getConfig();
- *   
- *   // Access HTTP configuration (via singleton)
- *   const toolbox::SharedPtr<config::HttpConfig>& httpConfig = config.getHttpConfig();
+ *   const config::Config& config1 = config::Config::getConfig();
  *   
  *   // Or access directly using static method
  *   const toolbox::SharedPtr<config::HttpConfig>& httpConfig = config::Config::getHttpConfig();
@@ -51,12 +48,10 @@ namespace config {
  */
 class Config {
  public:
-    Config();
-    ~Config();
     static void loadConfig(const std::string& configFile);
     static Config& getConfig() { return getInstance(); }
     static const toolbox::SharedPtr<config::HttpConfig>&
-                     getHttpConfig() { return getInstance()._httpConfig; }
+                    getHttpConfig() { return getInstance()._httpConfig; }
     static size_t getTokenCount() { return getInstance()._tokenCount; }
     static void setHttpConfig
     (const toolbox::SharedPtr<config::HttpConfig>& httpConfig) {
@@ -67,6 +62,8 @@ class Config {
     }
 
  private:
+    Config();
+    ~Config();
     Config(const Config& other);
     Config& operator=(const Config& other);
 

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -14,23 +14,66 @@
 #include "../../toolbox/shared.hpp"
 
 namespace config {
-
+/**
+ * @class Config
+ * @brief Singleton class for managing server configuration
+ *
+ * This class implements the Singleton design pattern to provide centralized access
+ * to server configuration settings throughout the application. The configuration
+ * is loaded from a specified file and parsed into a structured representation.
+ *
+ * Key features:
+ * - Singleton pattern ensures only one configuration instance exists
+ * - Loading and parsing of configuration files
+ * - Global access to HTTP configuration
+ *
+ * Usage example:
+ * @code
+ *   // Load configuration file
+ *   config::Config::loadConfig("server.conf");
+ *   
+ *   // Get singleton instance
+ *   const config::Config& config = config::Config::getConfig();
+ *   
+ *   // Access HTTP configuration (via singleton)
+ *   const toolbox::SharedPtr<config::HttpConfig>& httpConfig = config.getHttpConfig();
+ *   
+ *   // Or access directly using static method
+ *   const toolbox::SharedPtr<config::HttpConfig>& httpConfig = config::Config::getHttpConfig();
+ *   
+ *   // Use configuration values
+ *   std::string root = httpConfig->getRoot();
+ *   
+ * @endcode
+ *
+ * @note In C++98 environments, thread safety is not guaranteed. For multi-threaded
+ *       applications, it is recommended to load the configuration before creating threads.
+ */
 class Config {
  public:
     Config();
     ~Config();
-
-    const toolbox::SharedPtr<config::HttpConfig>& getHttpConfig() const { return _http_config; }
-    void setHttpConfig(const toolbox::SharedPtr<config::HttpConfig>& http_config) { _http_config = http_config; }
-    size_t getTokenCount() const { return _token_count; }
-    void setTokenCount(const size_t token_count) { _token_count = token_count; }
+    static void loadConfig(const std::string& configFile);
+    static Config& getConfig() { return getInstance(); }
+    static const toolbox::SharedPtr<config::HttpConfig>&
+                     getHttpConfig() { return getInstance()._httpConfig; }
+    static size_t getTokenCount() { return getInstance()._tokenCount; }
+    static void setHttpConfig
+    (const toolbox::SharedPtr<config::HttpConfig>& httpConfig) {
+        getInstance()._httpConfig = httpConfig;
+    }
+    static void setTokenCount(const size_t tokenCount) {
+        getInstance()._tokenCount = tokenCount;
+    }
 
  private:
     Config(const Config& other);
     Config& operator=(const Config& other);
 
-    toolbox::SharedPtr<config::HttpConfig> _http_config;
-    size_t _token_count;
+    toolbox::SharedPtr<config::HttpConfig> _httpConfig;
+    size_t _tokenCount;
+
+    static Config& getInstance();
 };
 
 class ConfigException : public std::exception {

--- a/src/config/config_base.hpp
+++ b/src/config/config_base.hpp
@@ -7,7 +7,25 @@
 #include "config_namespace.hpp"
 
 namespace config {
-
+/**
+ * @class ErrorPage
+ * @brief Class for managing error page settings
+ *
+ * Maps HTTP error status codes to corresponding display page paths.
+ * Multiple status codes can be mapped to a single error page.
+ *
+ * Usage example:
+ * @code
+ * ErrorPage errorPage;
+ * errorPage.addCode(404);
+ * errorPage.addCode(403);
+ * errorPage.setPath("/404.html");
+ * 
+ * // Accessing the configured settings
+ * const std::vector<size_t>& codes = errorPage.getCodes(); // Returns [404, 403]
+ * const std::string& path = errorPage.getPath();           // Returns "/404.html"
+ * @endcode
+ */
 class ErrorPage {
  public:
     ErrorPage();
@@ -25,6 +43,26 @@ class ErrorPage {
     std::string _path;
 };
 
+/**
+ * @class Listen
+ * @brief Class for managing server listening settings
+ *
+ * Maintains the combination of IP address and port number that the server
+ * listens on, as well as configuration as a default server.
+ *
+ * Usage example:
+ * @code
+ * Listen listen;
+ * listen.setPort(80);
+ * listen.setIp("0.0.0.0");
+ * listen.setDefaultServer(true);
+ * 
+ * // Accessing the configured settings
+ * size_t port = listen.getPort();                // Returns 80
+ * const std::string& ip = listen.getIp();        // Returns "0.0.0.0"
+ * bool isDefault = listen.isDefaultServer();     // Returns true
+ * @endcode
+ */
 class Listen {
  public:
     Listen();
@@ -45,6 +83,30 @@ class Listen {
     bool _default_server;
 };
 
+/**
+ * @class ServerName
+ * @brief Class for managing server name settings
+ *
+ * Manages server name settings for virtual hosting functionality.
+ * Supports three types of matching: exact match, wildcard prefix, and wildcard suffix.
+ *
+ * Usage example:
+ * @code
+ * ServerName serverName;
+ * serverName.setName("example.com");
+ * serverName.setType(ServerName::EXACT);
+ * 
+ * // Accessing the configured settings
+ * const std::string& name = serverName.getName();       // Returns "example.com"
+ * ServerName::ServerNameType type = serverName.getType(); // Returns ServerName::EXACT
+ * 
+ * // Wildcard example
+ * ServerName wildcard;
+ * wildcard.setName("example.com");
+ * wildcard.setType(ServerName::WILDCARD_START);
+ * // This represents *.example.com
+ * @endcode
+ */
 class ServerName {
  public:
     enum ServerNameType {
@@ -67,6 +129,28 @@ class ServerName {
     ServerNameType _type;
 };
 
+/**
+ * @class Return
+ * @brief Class for managing redirect settings
+ *
+ * Manages HTTP redirect settings. Can combine status codes with
+ * optional text or URLs.
+ *
+ * Usage example:
+ * @code
+ * Return redirect;
+ * redirect.setStatusCode(301);
+ * redirect.setTextOrUrl("https://example.com");
+ * redirect.setIsTextOrUrlSetting(true);
+ * redirect.setHasReturnValue(true);
+ * 
+ * // Accessing the configured settings
+ * size_t code = redirect.getStatusCode();                // Returns 301
+ * const std::string& url = redirect.getTextOrUrl();      // Returns "https://example.com"
+ * bool hasUrl = redirect.isTextOrUrlSetting();           // Returns true
+ * bool hasValue = redirect.hasReturnValue();             // Returns true
+ * @endcode
+ */
 class Return {
  public:
     Return();
@@ -90,6 +174,41 @@ class Return {
     bool _has_return_value;
 };
 
+/**
+ * @class ConfigBase
+ * @brief Base class for web server configuration
+ *
+ * An abstract base class that manages basic server configuration items.
+ * Serves as a common foundation for HTTP, server, and location configuration classes.
+ *
+ * Key configuration items:
+ * - Allowed HTTP methods
+ * - Directory listing (autoindex)
+ * - CGI extensions and execution path
+ * - Maximum client body size
+ * - Error page mappings
+ * - Index files
+ * - Document root
+ * - Upload directory
+ *
+ * @note This class is intended to be used as a base class and
+ * inherited by specific configuration classes.
+ *
+ * Usage example:
+ * @code
+ * ConfigBase* config = new ServerConfig();
+ * config->setRoot("/var/www");
+ * config->setAutoindex(true);
+ * config->addAllowedMethod("GET");
+ * config->addAllowedMethod("POST");
+ * 
+ * // Accessing the configured settings
+ * const std::string& root = config->getRoot();           // Returns "/var/www"
+ * bool autoindex = config->getAutoindex();               // Returns true
+ * const std::vector<std::string>& methods = config->getAllowedMethods(); // Returns ["GET", "POST"]
+ * size_t maxBodySize = config->getClientMaxBodySize();   // Returns default or configured value
+ * @endcode
+ */
 class ConfigBase {
  public:
     ConfigBase();

--- a/src/config/config_http.hpp
+++ b/src/config/config_http.hpp
@@ -11,7 +11,34 @@
 #include "../../toolbox/shared.hpp"
 
 namespace config {
-
+/**
+ * @class HttpConfig
+ * @brief Class for managing HTTP server configuration
+ *
+ * This class extends the ConfigBase class to provide HTTP-specific configuration
+ * capabilities. It serves as the top-level configuration container that holds
+ * multiple server configurations. Each server configuration represents a virtual
+ * server that can listen on specific IP:port combinations.
+ *
+ * The HttpConfig class inherits all common configuration properties from ConfigBase
+ * such as allowed methods, autoindex settings, client_max_body_size, etc., which
+ * serve as default values for all contained servers.
+ *
+ * Usage example:
+ * @code
+ * HttpConfig httpConfig;
+ * toolbox::SharedPtr<ServerConfig> server1(new ServerConfig());
+ * toolbox::SharedPtr<ServerConfig> server2(new ServerConfig());
+ * 
+ * // Add servers to HTTP config
+ * httpConfig.addServer(server1);
+ * httpConfig.addServer(server2);
+ * 
+ * // Accessing the configured settings
+ * const std::vector<toolbox::SharedPtr<ServerConfig> >& servers = httpConfig.getServers();
+ * size_t serverCount = servers.size();  // Returns 2
+ * @endcode
+ */
 class HttpConfig : public ConfigBase {
  public:
     HttpConfig();

--- a/src/config/config_location.cpp
+++ b/src/config/config_location.cpp
@@ -20,8 +20,8 @@ LocationConfig::LocationConfig(const LocationConfig& other) :
 ConfigBase(other),
 _path(other._path),
 _return_value(other._return_value),
-_parent_server(NULL),
-_parent_location(NULL) {
+_parent_server(other._parent_server),
+_parent_location(other._parent_location) {
     for (size_t i = 0; i < other._locations.size(); ++i) {
         toolbox::SharedPtr<LocationConfig> new_location(new LocationConfig(*other._locations[i]));
         _locations.push_back(new_location);

--- a/src/config/config_location.hpp
+++ b/src/config/config_location.hpp
@@ -14,7 +14,27 @@ namespace config {
 
 class HttpConfig;
 class ServerConfig;
-
+/**
+ * @class LocationConfig
+ * @brief Class for managing location-specific configuration settings
+ *
+ * This class extends ConfigBase to provide path-specific configuration capabilities.
+ * Each instance represents a URL location within a server that can have its own
+ * configuration settings. Locations can be nested to form a hierarchy.
+ * 
+ * LocationConfig inherits common configuration properties from ConfigBase and maintains
+ * references to its parent server and/or parent location for inheritance of settings.
+ *
+ * Usage example:
+ * @code
+ * // Accessing location configuration settings
+ * const std::string& path = location->getPath();                // Returns the URL path (e.g., "/images")
+ * const Return& returnValue = location->getReturnValue();       // Gets any configured redirect
+ * const std::vector<toolbox::SharedPtr<LocationConfig> >& childLocations = location->getLocations();
+ * const ServerConfig* parentServer = location->getServerParent();
+ * const LocationConfig* parentLocation = location->getLocationParent();
+ * @endcode
+ */
 class LocationConfig : public ConfigBase {
  public:
     LocationConfig();

--- a/src/config/config_parser.cpp
+++ b/src/config/config_parser.cpp
@@ -23,24 +23,20 @@ _config(toolbox::SharedPtr<HttpConfig>(new HttpConfig())) {
 ConfigParser::~ConfigParser() {
 }
 
-toolbox::SharedPtr<Config> ConfigParser::parseFile(const std::string& filepath) {
-    ConfigParser parser;
-    if (!parser.readFile(filepath)) {
+toolbox::SharedPtr<HttpConfig> ConfigParser::parseFile(const std::string& filepath) {
+    if (!readFile(filepath)) {
         throwConfigError("open() \"" + filepath + "\" failed");
     }
     ConfigLexer lexer;
-    parser._tokens = lexer.tokenize(parser._input);
-    toolbox::SharedPtr<Config> config(new Config());
-    if (parser._tokens.empty()) {
+    _tokens = lexer.tokenize(_input);
+    if (_tokens.empty()) {
         toolbox::logger::StepMark::warning("No tokens found in config file.");
-        return config;
+        return toolbox::SharedPtr<HttpConfig>(new HttpConfig());
     }
-    if (!parser.parse()) {
+    if (!parse()) {
         throwConfigError("Failed to parse configuration");
     }
-    config->setHttpConfig(parser._config);
-    config->setTokenCount(parser._tokens.size());
-    return config;
+    return _config;
 }
 
 bool ConfigParser::readFile(const std::string& filepath) {

--- a/src/config/config_parser.hpp
+++ b/src/config/config_parser.hpp
@@ -16,13 +16,14 @@ class LocationConfig;
 class HttpConfig;
 class ConfigParser {
  public:
-    static toolbox::SharedPtr<Config> parseFile(const std::string& filepath);
-
- private:
     ConfigParser();
     ~ConfigParser();
+    toolbox::SharedPtr<Config> parseFile(const std::string& filepath);
+
+ private:
     ConfigParser(const ConfigParser&);
     ConfigParser& operator=(const ConfigParser&);
+
     bool readFile(const std::string& filepath);
     bool parse();
     bool parseHttpBlock(const std::vector<std::string>& tokens, size_t* pos);

--- a/src/config/config_parser.hpp
+++ b/src/config/config_parser.hpp
@@ -18,7 +18,8 @@ class ConfigParser {
  public:
     ConfigParser();
     ~ConfigParser();
-    toolbox::SharedPtr<Config> parseFile(const std::string& filepath);
+    toolbox::SharedPtr<HttpConfig> parseFile(const std::string& filepath);
+    size_t getTokenCount() const { return _tokens.size(); }
 
  private:
     ConfigParser(const ConfigParser&);

--- a/src/config/config_server.cpp
+++ b/src/config/config_server.cpp
@@ -23,7 +23,7 @@ ConfigBase(other),
 _listens(other._listens),
 _server_names(other._server_names),
 _return_value(other._return_value),
-_parent(NULL) {
+_parent(other._parent) {
     for (size_t i = 0; i < other._locations.size(); ++i) {
         toolbox::SharedPtr<LocationConfig> new_location(new LocationConfig(*other._locations[i]));
         _locations.push_back(new_location);

--- a/src/config/config_server.hpp
+++ b/src/config/config_server.hpp
@@ -10,7 +10,35 @@
 #include "../../toolbox/shared.hpp"
 
 namespace config {
-
+/**
+ * @class ServerConfig
+ * @brief Class for managing server configuration settings
+ *
+ * This class extends ConfigBase to provide server-specific configuration capabilities.
+ * Each instance represents a virtual server that can listen on specific IP:port 
+ * combinations and respond to requests for specific server names (domains).
+ * 
+ * ServerConfig inherits common configuration properties from ConfigBase and can
+ * contain multiple location configurations for path-specific settings. It also
+ * maintains a reference to its parent HttpConfig to access global defaults.
+ *
+ * Usage example:
+ * @code
+ * ServerConfig server;
+ * 
+ * // Copy an existing location with modifications
+ * LocationConfig* copyOfLocation = new LocationConfig(*location);
+ * toolbox::SharedPtr<LocationConfig> newLocation(copyOfLocation);
+ * newLocation->setPath("/api/v2");
+ * newLocation->setRoot("/var/www/api/v2");
+ * server.addLocation(newLocation);
+ * 
+ * // Accessing the configured settings
+ * const std::vector<Listen>& listens = server.getListens();
+ * const std::vector<ServerName>& names = server.getServerNames();
+ * const std::vector<toolbox::SharedPtr<LocationConfig> >& locations = server.getLocations();
+ * @endcode
+ */
 class ServerConfig : public ConfigBase {
  public:
     ServerConfig();

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -20,13 +20,13 @@
 
 int main(int argc, char* argv[]) {
     try {
-        toolbox::SharedPtr<config::Config> config;
         if (argc == 1) {
-            config = config::ConfigParser::parseFile(config::DEFAULT_FILE);
+            config::Config::loadConfig(config::DEFAULT_FILE);
         } else if (argc == 2) {
-            config = config::ConfigParser::parseFile(argv[1]);
+            config::Config::loadConfig(argv[1]);
         }
-        toolbox::SharedPtr<config::HttpConfig> http_config = config->getHttpConfig();
+        const config::Config& config = config::Config::getConfig();
+        toolbox::SharedPtr<config::HttpConfig> http_config = config.getHttpConfig();
         toolbox::SharedPtr<config::ServerConfig> server_config1 = http_config->getServers()[0];
         toolbox::SharedPtr<config::ServerConfig> server_config2 = http_config->getServers()[1];
 

--- a/test/config/config_test_main.cpp
+++ b/test/config/config_test_main.cpp
@@ -110,18 +110,17 @@ int main(int argc, char* argv[]) {
         g_filter_directive = argv[2];
     }
     try {
-        toolbox::SharedPtr<config::Config> config;
         try {
             if (argc == 1) {
-                config = config::ConfigParser::parseFile("../../conf/default.conf");
+                config::Config::loadConfig("../../conf/default.conf");
             } else if (argc >= 2) {
-                config = config::ConfigParser::parseFile(argv[1]);
+                config::Config::loadConfig(argv[1]);
             }
         } catch (const std::exception& e) {
             std::cerr << e.what() << std::endl;
             return EXIT_FAILURE;
         }
-        const toolbox::SharedPtr<config::HttpConfig>& http = config->getHttpConfig();
+        const toolbox::SharedPtr<config::HttpConfig>& http = config::Config::getHttpConfig();
         if (!http) {
             return EXIT_SUCCESS;
         }


### PR DESCRIPTION
## 概要

* AccessLogクラスに倣ってConfigクラスをシングルトン化

## 変更内容
- Configクラスをシングルトン化
- シングルトン以外の軽微な修正
  - 他クラスで使用するであろうBaseConfig, HttpConfig, ServerConfig, LocationConfigのクラスに対して概要のコメントを追加
  - ServerConfig, LocationConfigをコピーする際の親情報もコピーするように変更

## 関連Issue

* #87 

## 影響範囲

* configを呼び出す部分

## テスト

* 既存のテストが問題なく実行できるかの確認（test/configに移動して`make run`）

## その他

- 設定ファイルの情報を使いたい場所で以下を記載
```
const config::Config& config = config::Config::getConfig();
toolbox::SharedPtr<config::HttpConfig> http_config = config::Config::getHttpConfig();
```
`config`の文字が多すぎてややこしいもっと綺麗な方法ないのか！？

- どのサーバであるかを特定する、どのlocationであるかを特定するような関数をリクエストクラス、CGIクラスでも使う気がするので汎用的にconfig関連のソースコードに作成してもいいかも

- 設定ファイル関連のソースコードは引数の名前をスネークケースで書いてしまっているので、キャメルケースに直さないといけない

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | `Config`クラスがシングルトンパターンに変更され、設定ファイルを読み込むための`loadConfig`メソッドが追加されました。 |
| Bug fix | `LocationConfig`と`ServerConfig`のコピーコンストラクタで親情報が正しくコピーされるよう修正されました。 |
| Documentation | 各種設定クラスに詳細なドキュメントコメントが追加され、可読性が向上しました。 |
| Refactor | `ConfigParser::parseFile`メソッドが非staticに変更され、インスタンス生成が必要になりました。 |

このプルリクエストでは、コードの構造を改善しつつ、ドキュメントを充実させることで、開発者がより理解しやすく、保守しやすいコードベースを提供しています。特に、シングルトンパターンの導入によって、設定管理が一貫して行えるようになった点が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->