### PR TITLE
26 postメソッド

### DIFF
--- a/src/http/http_namespace.cpp
+++ b/src/http/http_namespace.cpp
@@ -65,6 +65,7 @@ const char* SLASH = "/";
 const char* QUESTION = "?";
 const char* PERCENT = "%";
 const char* COLON = ":";
+const char* SEMICOLON = ";";
 const char* COMMA = ",";
 const char* COMMASP = ", ";
 }  // namespace symbols

--- a/src/http/http_namespace.hpp
+++ b/src/http/http_namespace.hpp
@@ -62,6 +62,7 @@ extern const char* SLASH;
 extern const char* QUESTION;
 extern const char* PERCENT;
 extern const char* COLON;
+extern const char* SEMICOLON;
 extern const char* COMMA;
 extern const char* COMMASP;
 }  // namespace symbols

--- a/src/http/response/content_type_manager.cpp
+++ b/src/http/response/content_type_manager.cpp
@@ -15,7 +15,7 @@ std::string extractExtension(const std::string& filename) {
 }
 }
 
-void ContentTypeManager::initContentTypeMap() {
+ContentTypeManager::ContentTypeManager() {
     _contentTypeMap["html"] = "text/html";
     _contentTypeMap["htm"] = "text/html";
     _contentTypeMap["css"] = "text/css";

--- a/src/http/response/content_type_manager.cpp
+++ b/src/http/response/content_type_manager.cpp
@@ -6,7 +6,11 @@ std::map<std::string, std::string> ContentTypeManager::_contentTypeMap;
 
 namespace {
 std::string extractExtension(const std::string& filename) {
-    std::string extension = filename.substr(filename.find_last_of('.') + 1);
+    std::size_t dot_pos = filename.find_last_of('.');
+    if (dot_pos == std::string::npos) {
+        return "";
+    }
+    std::string extension = filename.substr(dot_pos + 1);
     return extension;
 }
 }

--- a/src/http/response/content_type_manager.cpp
+++ b/src/http/response/content_type_manager.cpp
@@ -45,9 +45,6 @@ void ContentTypeManager::initContentTypeMap() {
 }
 
 std::string ContentTypeManager::getContentType(const std::string& filename) {
-    if (_contentTypeMap.empty()) {
-        initContentTypeMap();
-    }
     std::string extension = extractExtension(filename);
     if (_contentTypeMap.find(extension) != _contentTypeMap.end()) {
         return _contentTypeMap[extension];
@@ -56,9 +53,6 @@ std::string ContentTypeManager::getContentType(const std::string& filename) {
 }
 
 std::string ContentTypeManager::getExtension(const std::string& content_type) {
-    if (_contentTypeMap.empty()) {
-        initContentTypeMap();
-    }
     if (content_type.empty()) {
         return "";
     }

--- a/src/http/response/content_type_manager.cpp
+++ b/src/http/response/content_type_manager.cpp
@@ -1,0 +1,75 @@
+#include "content_type_manager.hpp"
+
+namespace http {
+
+std::map<std::string, std::string> ContentTypeManager::_contentTypeMap;
+
+namespace {
+std::string extractExtension(const std::string& filename) {
+    std::string extension = filename.substr(filename.find_last_of('.') + 1);
+    return extension;
+}
+}
+
+ContentTypeManager::ContentTypeManager() {
+}
+
+ContentTypeManager::~ContentTypeManager() {
+}
+
+void ContentTypeManager::initContentTypeMap() {
+    _contentTypeMap["html"] = "text/html";
+    _contentTypeMap["htm"] = "text/html";
+    _contentTypeMap["css"] = "text/css";
+    _contentTypeMap["js"] = "application/javascript";
+    _contentTypeMap["json"] = "application/json";
+    _contentTypeMap["txt"] = "text/plain";
+    _contentTypeMap["jpg"] = "image/jpeg";
+    _contentTypeMap["jpeg"] = "image/jpeg";
+    _contentTypeMap["png"] = "image/png";
+    _contentTypeMap["gif"] = "image/gif";
+    _contentTypeMap["svg"] = "image/svg+xml";
+    _contentTypeMap["ico"] = "image/x-icon";
+    _contentTypeMap["pdf"] = "application/pdf";
+    _contentTypeMap["xml"] = "application/xml";
+    _contentTypeMap["zip"] = "application/zip";
+    _contentTypeMap["gz"] = "application/gzip";
+    _contentTypeMap["tar"] = "application/x-tar";
+    _contentTypeMap["mp3"] = "audio/mpeg";
+    _contentTypeMap["mp4"] = "video/mp4";
+    _contentTypeMap["avi"] = "video/x-msvideo";
+    _contentTypeMap["php"] = "application/x-httpd-php";
+    _contentTypeMap["py"] = "text/x-python";
+    _contentTypeMap["c"] = "text/x-c";
+    _contentTypeMap["cpp"] = "text/x-c++";
+    _contentTypeMap["h"] = "text/x-c";
+    _contentTypeMap["hpp"] = "text/x-c++";
+}
+
+std::string ContentTypeManager::getContentType(const std::string& filename) {
+    if (_contentTypeMap.empty()) {
+        initContentTypeMap();
+    }
+    std::string extension = extractExtension(filename);
+    if (_contentTypeMap.find(extension) != _contentTypeMap.end()) {
+        return _contentTypeMap[extension];
+    }
+    return "application/octet-stream";
+}
+
+std::string ContentTypeManager::getExtension(const std::string& content_type) {
+    if (_contentTypeMap.empty()) {
+        initContentTypeMap();
+    }
+    if (content_type.empty()) {
+        return "";
+    }
+    for (ContentTypeMap::const_iterator it = _contentTypeMap.begin(); it != _contentTypeMap.end(); ++it) {
+        if (it->second == content_type) {
+            return it->first;
+        }
+    }
+    return "";
+}
+
+}  // namespace http

--- a/src/http/response/content_type_manager.cpp
+++ b/src/http/response/content_type_manager.cpp
@@ -15,12 +15,6 @@ std::string extractExtension(const std::string& filename) {
 }
 }
 
-ContentTypeManager::ContentTypeManager() {
-}
-
-ContentTypeManager::~ContentTypeManager() {
-}
-
 void ContentTypeManager::initContentTypeMap() {
     _contentTypeMap["html"] = "text/html";
     _contentTypeMap["htm"] = "text/html";

--- a/src/http/response/content_type_manager.hpp
+++ b/src/http/response/content_type_manager.hpp
@@ -11,13 +11,17 @@ typedef std::map<std::string, std::string> ContentTypeMap;
 
 class ContentTypeManager {
  public:
-    static std::string getContentType(const std::string& filename);
-    static std::string getExtension(const std::string& filename);
+    static ContentTypeManager& getInstance() {
+        static ContentTypeManager instance;
+        return instance;
+    }
+    std::string getContentType(const std::string& filename);
+    std::string getExtension(const std::string& filename);
  private:
     static void initContentTypeMap();
     static ContentTypeMap _contentTypeMap;
-    ContentTypeManager();
-    ~ContentTypeManager();
+    ContentTypeManager() { initContentTypeMap(); };
+    ~ContentTypeManager() {};
     ContentTypeManager(const ContentTypeManager&);
     ContentTypeManager& operator=(const ContentTypeManager&) { return *this; };
 };

--- a/src/http/response/content_type_manager.hpp
+++ b/src/http/response/content_type_manager.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "method_utils.hpp"
+
+namespace http {
+
+typedef std::map<std::string, std::string> ContentTypeMap;
+
+class ContentTypeManager {
+ public:
+    static std::string getContentType(const std::string& filename);
+    static std::string getExtension(const std::string& filename);
+ private:
+    static void initContentTypeMap();
+    static ContentTypeMap _contentTypeMap;
+    ContentTypeManager();
+    ~ContentTypeManager();
+    ContentTypeManager(const ContentTypeManager&) {};
+    ContentTypeManager& operator=(const ContentTypeManager&) { return *this; };
+};
+
+}  // namespace http

--- a/src/http/response/content_type_manager.hpp
+++ b/src/http/response/content_type_manager.hpp
@@ -17,13 +17,16 @@ class ContentTypeManager {
     }
     std::string getContentType(const std::string& filename);
     std::string getExtension(const std::string& filename);
+
  private:
-    static void initContentTypeMap();
     static ContentTypeMap _contentTypeMap;
+
     ContentTypeManager() { initContentTypeMap(); };
     ~ContentTypeManager() {};
     ContentTypeManager(const ContentTypeManager&);
     ContentTypeManager& operator=(const ContentTypeManager&) { return *this; };
+
+    static void initContentTypeMap();
 };
 
 }  // namespace http

--- a/src/http/response/content_type_manager.hpp
+++ b/src/http/response/content_type_manager.hpp
@@ -21,12 +21,10 @@ class ContentTypeManager {
  private:
     static ContentTypeMap _contentTypeMap;
 
-    ContentTypeManager() { initContentTypeMap(); };
+    ContentTypeManager();
     ~ContentTypeManager() {};
     ContentTypeManager(const ContentTypeManager&);
     ContentTypeManager& operator=(const ContentTypeManager&) { return *this; };
-
-    static void initContentTypeMap();
 };
 
 }  // namespace http

--- a/src/http/response/content_type_manager.hpp
+++ b/src/http/response/content_type_manager.hpp
@@ -18,7 +18,7 @@ class ContentTypeManager {
     static ContentTypeMap _contentTypeMap;
     ContentTypeManager();
     ~ContentTypeManager();
-    ContentTypeManager(const ContentTypeManager&) {};
+    ContentTypeManager(const ContentTypeManager&);
     ContentTypeManager& operator=(const ContentTypeManager&) { return *this; };
 };
 

--- a/src/http/response/delete_method.cpp
+++ b/src/http/response/delete_method.cpp
@@ -37,12 +37,12 @@ void runDelete(const std::string& path, Response& response) {
                 + path + " " + toolbox::to_string(HttpStatus::INTERNAL_SERVER_ERROR));
             throw HttpStatus::INTERNAL_SERVER_ERROR;
         }
+        response.setStatus(HttpStatus::NO_CONTENT);
     } catch (const HttpStatus::EHttpStatus& e) {
         toolbox::logger::StepMark::error("runDelete: set status "
             + toolbox::to_string(e));
         response.setStatus(e);
     }
-    response.setStatus(HttpStatus::NO_CONTENT);
 }
 
 }  // namespace http

--- a/src/http/response/delete_method.cpp
+++ b/src/http/response/delete_method.cpp
@@ -4,46 +4,45 @@
 namespace http {
 
 namespace {
-HttpStatus::EHttpStatus handleFile(const std::string& path) {
+void handleFile(const std::string& path) {
     if (std::remove(path.c_str()) != 0) {
         toolbox::logger::StepMark::error("runDelete: remove fail "
             + path + " " + toolbox::to_string(HttpStatus::INTERNAL_SERVER_ERROR));
-        return HttpStatus::INTERNAL_SERVER_ERROR;
+        throw HttpStatus::INTERNAL_SERVER_ERROR;
     }
     toolbox::logger::StepMark::info("runDelete: remove success "
         + path + " " + toolbox::to_string(HttpStatus::NO_CONTENT));
-    return HttpStatus::NO_CONTENT;
 }
 }  // namespace
 
 void runDelete(const std::string& path, Response& response) {
     struct stat st;
 
-    HttpStatus::EHttpStatus status = checkFileAccess(path, st);
-    if (status != HttpStatus::OK) {
-        toolbox::logger::StepMark::error("runDelete: checkFileAccess fail "
-            + path + " " + toolbox::to_string(status));
-        response.setStatus(status);
-    } else {
-        try {
-            if (isDirectory(st)) {
-                toolbox::logger::StepMark::error("runDelete: isDirectory "
-                    + path + " " + toolbox::to_string(HttpStatus::FORBIDDEN));
-                response.setStatus(HttpStatus::FORBIDDEN);
-            } else if (isRegularFile(st)) {
-                response.setStatus(handleFile(path));
-            } else {
-                toolbox::logger::StepMark::error("runDelete: not a regularfile "
-                    + path + " " + toolbox::to_string(HttpStatus::INTERNAL_SERVER_ERROR));
-                response.setStatus(HttpStatus::INTERNAL_SERVER_ERROR);
-            }
-        } catch (const std::exception& e) {
-            response.setStatus(HttpStatus::INTERNAL_SERVER_ERROR);
-            toolbox::logger::StepMark::error("runDelete: exception "
-                + std::string(e.what()) + " "
-                + toolbox::to_string(HttpStatus::INTERNAL_SERVER_ERROR));
+    try {
+        HttpStatus::EHttpStatus status = checkFileAccess(path, st);
+        if (status != HttpStatus::OK) {
+            toolbox::logger::StepMark::error("runDelete: checkFileAccess fail "
+                + path + " " + toolbox::to_string(status));
+            throw status;
         }
+
+        if (isDirectory(st)) {
+            toolbox::logger::StepMark::error("runDelete: isDirectory "
+                + path + " " + toolbox::to_string(HttpStatus::FORBIDDEN));
+            throw HttpStatus::FORBIDDEN;
+        } else if (isRegularFile(st)) {
+            handleFile(path);
+        } else {
+            toolbox::logger::StepMark::error("runDelete: not a regularfile "
+                + path + " " + toolbox::to_string(HttpStatus::INTERNAL_SERVER_ERROR));
+            throw HttpStatus::INTERNAL_SERVER_ERROR;
+        }
+    } catch (const HttpStatus::EHttpStatus& e) {
+        toolbox::logger::StepMark::error("runDelete: set status "
+            + toolbox::to_string(e));
+        response.setStatus(e);
     }
+    response.setStatus(HttpStatus::NO_CONTENT);
 }
 
 }  // namespace http

--- a/src/http/response/get_method.cpp
+++ b/src/http/response/get_method.cpp
@@ -114,7 +114,7 @@ void handleDirectory(const std::string& path, const std::string& indexPath,
             throw status;
         }
         response.setBody(readFile(fullPath));
-        response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getContentType(fullPath));
+        response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getInstance().getContentType(fullPath));
         response.setHeader(fields::LAST_MODIFIED, getModifiedTime(indexSt));
     }  else if (isAutoindex) {
         response.setBody(processAutoindex(path));
@@ -124,7 +124,7 @@ void handleDirectory(const std::string& path, const std::string& indexPath,
 
 void handleFile(const std::string& path, Response& response) {
     response.setBody(readFile(path));
-    response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getContentType(path));
+    response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getInstance().getContentType(path));
 }
 }  // namespace
 

--- a/src/http/response/get_method.cpp
+++ b/src/http/response/get_method.cpp
@@ -100,10 +100,8 @@ std::string processAutoindex(const std::string& path) {
     return ss.str();
 }
 
-HttpStatus::EHttpStatus handleDirectory(const std::string& path,
-                                        const std::string& indexPath,
-                                        Response& response,
-                                        bool isAutoindex) {
+void handleDirectory(const std::string& path, const std::string& indexPath,
+                     Response& response, bool isAutoindex) {
     HttpStatus::EHttpStatus status;
 
     if (!indexPath.empty()) {
@@ -113,7 +111,7 @@ HttpStatus::EHttpStatus handleDirectory(const std::string& path,
         if (status != HttpStatus::OK) {
             toolbox::logger::StepMark::error("runGet: checkFileAccess fail "
                 + fullPath + " " + toolbox::to_string(status));
-            return status;
+            throw status;
         }
         response.setBody(readFile(fullPath));
         response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getContentType(fullPath));
@@ -122,45 +120,39 @@ HttpStatus::EHttpStatus handleDirectory(const std::string& path,
         response.setBody(processAutoindex(path));
         response.setHeader(fields::CONTENT_TYPE, "text/html");
     }
-    return HttpStatus::OK;
 }
 
-HttpStatus::EHttpStatus handleFile(const std::string& path,
-                                   Response& response) {
+void handleFile(const std::string& path, Response& response) {
     response.setBody(readFile(path));
     response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getContentType(path));
-    return HttpStatus::OK;
 }
 }  // namespace
 
-HttpStatus::EHttpStatus runGet(const std::string& path,
-                               const std::string& indexPath,
-                               bool isAutoindex,
-                               Response& response) {
+void runGet(const std::string& path, const std::string& indexPath,
+            bool isAutoindex, Response& response) {
     struct stat st;
 
-    HttpStatus::EHttpStatus status = checkFileAccess(path, st);
-    if (status != HttpStatus::OK) {
-        toolbox::logger::StepMark::error("runGet: checkFileAccess fail " + path
-            + " " + toolbox::to_string(status));
-        return status;
-    }
-
     try {
-        if (isDirectory(st)) {
-            return handleDirectory(path, indexPath, response,
-                isAutoindex);
-        } else if (isRegularFile(st)) {
-            return handleFile(path, response);
-        } else {
-            status = HttpStatus::INTERNAL_SERVER_ERROR;
+        HttpStatus::EHttpStatus status = checkFileAccess(path, st);
+        if (status != HttpStatus::OK) {
+            toolbox::logger::StepMark::error("runGet: checkFileAccess fail " + path
+                + " " + toolbox::to_string(status));
+            throw status;
         }
-    } catch (const std::exception& e) {
-        status = HttpStatus::INTERNAL_SERVER_ERROR;
-        toolbox::logger::StepMark::error("runGet: exception "
-            + std::string(e.what()) + " " + toolbox::to_string(status));
+
+        if (isDirectory(st)) {
+            handleDirectory(path, indexPath, response, isAutoindex);
+        } else if (isRegularFile(st)) {
+            handleFile(path, response);
+        } else {
+            throw HttpStatus::INTERNAL_SERVER_ERROR;
+        }
+    } catch (const HttpStatus::EHttpStatus& e) {
+        toolbox::logger::StepMark::error("runGet: set status "
+            + toolbox::to_string(e));
+        response.setStatus(e);
     }
-    return status;
+    response.setStatus(HttpStatus::OK);
 }
 
 }  // namespace http

--- a/src/http/response/get_method.cpp
+++ b/src/http/response/get_method.cpp
@@ -147,12 +147,12 @@ void runGet(const std::string& path, const std::string& indexPath,
         } else {
             throw HttpStatus::INTERNAL_SERVER_ERROR;
         }
+        response.setStatus(HttpStatus::OK);
     } catch (const HttpStatus::EHttpStatus& e) {
         toolbox::logger::StepMark::error("runGet: set status "
             + toolbox::to_string(e));
         response.setStatus(e);
     }
-    response.setStatus(HttpStatus::OK);
 }
 
 }  // namespace http

--- a/src/http/response/get_method.hpp
+++ b/src/http/response/get_method.hpp
@@ -10,8 +10,6 @@
 #include "response.hpp"
 
 namespace http {
-HttpStatus::EHttpStatus runGet(const std::string& path,
-                               const std::string& indexPath,
-                               bool isAutoindex,
-                               Response& response);
+void runGet(const std::string& path, const std::string& indexPath,
+            bool isAutoindex, Response& response);
 }  // namespace http

--- a/src/http/response/get_method.hpp
+++ b/src/http/response/get_method.hpp
@@ -5,6 +5,7 @@
 
 #include "../case_insensitive_less.hpp"
 #include "../http_status.hpp"
+#include "content_type_manager.hpp"
 #include "method_utils.hpp"
 #include "response.hpp"
 
@@ -12,6 +13,5 @@ namespace http {
 HttpStatus::EHttpStatus runGet(const std::string& path,
                                const std::string& indexPath,
                                bool isAutoindex,
-                               ExtensionMap& extensionMap,
                                Response& response);
 }  // namespace http

--- a/src/http/response/head_method.cpp
+++ b/src/http/response/head_method.cpp
@@ -47,7 +47,7 @@ void runHead(const std::string& path, const std::string& indexPath,
     try {
         HttpStatus::EHttpStatus status = checkFileAccess(path, st);
         if (status != HttpStatus::OK) {
-            toolbox::logger::StepMark::error("runHead: runHead: checkFileAccess fail " + path + " " + toolbox::to_string(status));
+            toolbox::logger::StepMark::error("runHead: checkFileAccess fail " + path + " " + toolbox::to_string(status));
             throw status;
         }
 
@@ -58,12 +58,12 @@ void runHead(const std::string& path, const std::string& indexPath,
         } else {
             throw HttpStatus::INTERNAL_SERVER_ERROR;
         }
+        response.setStatus(HttpStatus::OK);
     } catch (const HttpStatus::EHttpStatus& e) {
         toolbox::logger::StepMark::error("runHead: set status "
             + toolbox::to_string(e));
         response.setStatus(e);
     }
-    response.setStatus(HttpStatus::OK);
 }
 
 }  // namespace http

--- a/src/http/response/head_method.cpp
+++ b/src/http/response/head_method.cpp
@@ -6,10 +6,10 @@
 #include "method_utils.hpp"
 
 namespace http {
+namespace {
 HttpStatus::EHttpStatus handleDirectory(const std::string& path,
                                         const std::string& indexPath,
                                         bool isAutoindex,
-                                        ExtensionMap& extensionMap,
                                         Response& response) {
     HttpStatus::EHttpStatus status;
 
@@ -22,7 +22,7 @@ HttpStatus::EHttpStatus handleDirectory(const std::string& path,
                 + fullPath + " " + toolbox::to_string(status));
             return status;
         }
-        response.setHeader(fields::CONTENT_TYPE, getContentType(fullPath, extensionMap));
+        response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getContentType(fullPath));
         response.setHeader(fields::LAST_MODIFIED, getModifiedTime(indexSt));
     }  else if (isAutoindex) {
         response.setHeader(fields::CONTENT_TYPE, "text/html");
@@ -31,7 +31,6 @@ HttpStatus::EHttpStatus handleDirectory(const std::string& path,
 }
 
 HttpStatus::EHttpStatus handleFile(const std::string& path,
-                                    ExtensionMap& extensionMap,
                                     Response& response) {
     struct stat st;
 
@@ -41,15 +40,15 @@ HttpStatus::EHttpStatus handleFile(const std::string& path,
             + path + " " + toolbox::to_string(status));
         return status;
     }
-    response.setHeader(fields::CONTENT_TYPE, getContentType(path, extensionMap));
+    response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getContentType(path));
     response.setHeader(fields::LAST_MODIFIED, getModifiedTime(st));
     return HttpStatus::OK;
 }
+}  // namespace
 
 HttpStatus::EHttpStatus runHead(const std::string& path,
                                const std::string& indexPath,
                                bool isAutoindex,
-                               ExtensionMap& extensionMap,
                                Response& response) {
     struct stat st;
 
@@ -62,10 +61,9 @@ HttpStatus::EHttpStatus runHead(const std::string& path,
 
     try {
         if (isDirectory(st)) {
-            status = handleDirectory(path, indexPath, isAutoindex,
-                extensionMap, response);
+            status = handleDirectory(path, indexPath, isAutoindex, response);
         } else if (isRegularFile(st)) {
-            status = handleFile(path, extensionMap, response);
+            status = handleFile(path, response);
         } else {
             status = HttpStatus::INTERNAL_SERVER_ERROR;
         }

--- a/src/http/response/head_method.cpp
+++ b/src/http/response/head_method.cpp
@@ -19,7 +19,7 @@ void handleDirectory(const std::string& path, const std::string& indexPath,
             toolbox::logger::StepMark::error("runHead: handleDirectory: checkFileAccess fail " + fullPath + " " + toolbox::to_string(status));
             throw status;
         }
-        response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getContentType(fullPath));
+        response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getInstance().getContentType(fullPath));
         response.setHeader(fields::LAST_MODIFIED, getModifiedTime(indexSt));
     }  else if (isAutoindex) {
         response.setHeader(fields::CONTENT_TYPE, "text/html");
@@ -35,7 +35,7 @@ void handleFile(const std::string& path, Response& response) {
             + path + " " + toolbox::to_string(status));
         throw status;
     }
-    response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getContentType(path));
+    response.setHeader(fields::CONTENT_TYPE, ContentTypeManager::getInstance().getContentType(path));
     response.setHeader(fields::LAST_MODIFIED, getModifiedTime(st));
 }
 }  // namespace

--- a/src/http/response/head_method.hpp
+++ b/src/http/response/head_method.hpp
@@ -11,8 +11,6 @@
 #include "response.hpp"
 
 namespace http {
-HttpStatus::EHttpStatus runHead(const std::string& path,
-                               const std::string& indexPath,
-                               bool isAutoindex,
-                               Response& response);
+void runHead(const std::string& path, const std::string& indexPath,
+            bool isAutoindex, Response& response);
 }  // namespace http

--- a/src/http/response/head_method.hpp
+++ b/src/http/response/head_method.hpp
@@ -6,6 +6,7 @@
 #include "../case_insensitive_less.hpp"
 #include "../http_status.hpp"
 #include "../request/http_fields.hpp"
+#include "content_type_manager.hpp"
 #include "method_utils.hpp"
 #include "response.hpp"
 
@@ -13,6 +14,5 @@ namespace http {
 HttpStatus::EHttpStatus runHead(const std::string& path,
                                const std::string& indexPath,
                                bool isAutoindex,
-                               ExtensionMap& extensionMap,
                                Response& response);
 }  // namespace http

--- a/src/http/response/method_utils.cpp
+++ b/src/http/response/method_utils.cpp
@@ -19,49 +19,6 @@ std::string joinPath(const std::string& base, const std::string& path) {
     return base + "/" + path;
 }
 
-std::string getContentType(const std::string& filename,
-                           const ExtensionMap& extensionMap) {
-    size_t pos = filename.find_last_of(".");
-    if (pos == std::string::npos || pos == filename.size()) {
-        return "application/octet-stream";
-    }
-    std::string ext = filename.substr(pos + 1);
-    ExtensionMap::const_iterator it = extensionMap.find(ext);
-    if (it != extensionMap.end()) {
-        return it->second;
-    }
-    return "application/octet-stream";
-}
-
-void initExtensionMap(ExtensionMap& extensionMap) {
-    extensionMap["html"] = "text/html";
-    extensionMap["htm"] = "text/html";
-    extensionMap["css"] = "text/css";
-    extensionMap["js"] = "application/javascript";
-    extensionMap["json"] = "application/json";
-    extensionMap["txt"] = "text/plain";
-    extensionMap["jpg"] = "image/jpeg";
-    extensionMap["jpeg"] = "image/jpeg";
-    extensionMap["png"] = "image/png";
-    extensionMap["gif"] = "image/gif";
-    extensionMap["svg"] = "image/svg+xml";
-    extensionMap["ico"] = "image/x-icon";
-    extensionMap["pdf"] = "application/pdf";
-    extensionMap["xml"] = "application/xml";
-    extensionMap["zip"] = "application/zip";
-    extensionMap["gz"] = "application/gzip";
-    extensionMap["tar"] = "application/x-tar";
-    extensionMap["mp3"] = "audio/mpeg";
-    extensionMap["mp4"] = "video/mp4";
-    extensionMap["avi"] = "video/x-msvideo";
-    extensionMap["php"] = "application/x-httpd-php";
-    extensionMap["py"] = "text/x-python";
-    extensionMap["c"] = "text/x-c";
-    extensionMap["cpp"] = "text/x-c++";
-    extensionMap["h"] = "text/x-c";
-    extensionMap["hpp"] = "text/x-c++";
-}
-
 HttpStatus::EHttpStatus checkFileAccess(const std::string& path,
                                         struct stat& st) {
     if (access(path.c_str(), F_OK) != 0) {

--- a/src/http/response/method_utils.cpp
+++ b/src/http/response/method_utils.cpp
@@ -5,13 +5,6 @@
 #include "method_utils.hpp"
 
 namespace http {
-bool isDirectory(const struct stat& st) {
-    return S_ISDIR(st.st_mode);
-}
-
-bool isRegularFile(const struct stat& st) {
-    return S_ISREG(st.st_mode);
-}
 
 std::string joinPath(const std::string& base, const std::string& path) {
     if (base.empty()) {

--- a/src/http/response/method_utils.hpp
+++ b/src/http/response/method_utils.hpp
@@ -21,8 +21,9 @@ struct FileInfo {
     size_t size;
 };
 
-bool isDirectory(const struct stat& st);
-bool isRegularFile(const struct stat& st);
+inline bool isDirectory(const struct stat& st) { return S_ISDIR(st.st_mode); }
+inline bool isRegularFile(const struct stat& st) { return S_ISREG(st.st_mode); }
+
 std::string joinPath(const std::string& base, const std::string& path);
 std::string getContentType(const std::string& filename,
                            const ExtensionMap& extensionMap);

--- a/src/http/response/method_utils.hpp
+++ b/src/http/response/method_utils.hpp
@@ -26,10 +26,6 @@ inline bool isDirectory(const struct stat& st) { return S_ISDIR(st.st_mode); }
 inline bool isRegularFile(const struct stat& st) { return S_ISREG(st.st_mode); }
 
 std::string joinPath(const std::string& base, const std::string& path);
-std::string getContentType(const std::string& filename,
-                           const ExtensionMap& extensionMap);
-void initExtensionMap(ExtensionMap& extensionMap);
-HttpStatus::EHttpStatus checkFileAccess(const std::string& path,
-                                        struct stat& st);
+HttpStatus::EHttpStatus checkFileAccess(const std::string& path, struct stat& st);
 std::string getModifiedTime(const struct stat& st);
 }  // namespace http

--- a/src/http/response/post_method.cpp
+++ b/src/http/response/post_method.cpp
@@ -1,0 +1,275 @@
+#include <string>
+#include <vector>
+#include <fstream>
+#include <iostream>
+
+#include <sys/stat.h>
+
+#include "../string_utils.hpp"
+#include "post_method.hpp"
+
+namespace http {
+namespace {
+bool startsWith(const std::string& str, const std::string& prefix) {
+    return str.find(prefix) == 0;
+}
+
+bool isMultipartFormData(HTTPFields& fields) {
+    HTTPFields::FieldValue contentType = fields.getFieldValue(fields::CONTENT_TYPE);
+    return !contentType.empty() && startsWith(contentType[0], "multipart/form-data");
+}
+
+bool isUrlEncoded(HTTPFields& fields) {
+    HTTPFields::FieldValue contentType = fields.getFieldValue(fields::CONTENT_TYPE);
+    return !contentType.empty() && startsWith(contentType[0], "application/x-www-form-urlencoded");
+}
+
+std::string getBoundary(HTTPFields& fields) {
+    std::string boundary = fields.getFieldValue(fields::CONTENT_TYPE)[0];
+    std::size_t pos = boundary.find("boundary=");
+    if (pos == std::string::npos) {
+        return "";
+    }
+    std::string boundaryStr = boundary.substr(pos + 9);  // "boundary=" len = 9
+    return "--" + boundaryStr;
+}
+
+// void writeToFile(const std::string& filename, const std::string& bodyPart) {
+//     std::ofstream ofs(filename.c_str(), std::ios_base::binary | std::ios_base::app);
+//     if (!ofs) {
+//         toolbox::logger::StepMark::error("runPost: writeToFile failed: " + filename);
+//         throw HttpStatus::INTERNAL_SERVER_ERROR;
+//     }
+//     ofs.write(reinterpret_cast<const char*>(bodyPart.c_str()), bodyPart.size());
+// }
+
+std::string getTimestamp() {
+    return toolbox::to_string(time(NULL));
+}
+
+void splitBodyByBoundary(std::vector<std::string>& bodyParts,
+                        std::string& recvBody,
+                        const std::string& boundary) {
+    std::string endBoundary = boundary + "--";
+    std::size_t pos = 0;
+    
+    while (pos < recvBody.length()) {
+        // Find the next boundary
+        std::size_t boundaryPos = recvBody.find(boundary, pos);
+        if (boundaryPos == std::string::npos) {
+            break;
+        }
+        
+        // Skip the boundary and any following newlines
+        pos = boundaryPos + boundary.length();
+        while (pos < recvBody.length() && 
+               (recvBody[pos] == '\r' || recvBody[pos] == '\n')) {
+            pos++;
+        }
+        
+        // Find the next boundary or end boundary
+        std::size_t nextBoundaryPos = recvBody.find(boundary, pos);
+        if (nextBoundaryPos == std::string::npos) {
+            nextBoundaryPos = recvBody.find(endBoundary, pos);
+            if (nextBoundaryPos == std::string::npos) {
+                break;
+            }
+        }
+        
+        // Extract the part between boundaries
+        std::string part = recvBody.substr(pos, nextBoundaryPos - pos);
+        if (!part.empty()) {
+            bodyParts.push_back(part);
+        }
+        
+        pos = nextBoundaryPos;
+    }
+}
+
+}  // namespace
+
+void handleCreateFile(const std::string& uploadPath, std::string filename, const std::string& body) {
+    std::cout << "handleCreateFile: " << filename << std::endl;
+    if (filename.empty()) {
+        filename = getTimestamp();
+    }
+    std::string filepath = joinPath(uploadPath, filename);
+    std::ofstream ofs(filepath.c_str(), std::ios::binary);
+    if (!ofs) {
+        toolbox::logger::StepMark::error("runPost: handleCreateFile failed: " + filepath);
+        throw HttpStatus::INTERNAL_SERVER_ERROR;
+    }
+    ofs.write(body.data(), body.size());
+}
+
+void handleNonExistUploadPath(Response& response) {
+    response.setBody("Upload path does not exist");
+    response.setStatus(HttpStatus::NOT_IMPLEMENTED);
+}
+
+void parseContentDisposition(std::string& bodyPart, FormDataField& formData) {
+    std::size_t pos = bodyPart.find("Content-Disposition: form-data;");
+    if (pos == std::string::npos) {
+        return;
+    }
+    std::string attributes = bodyPart.substr(pos + 31);  // "Content-Disposition: form-data;" の長さ
+    while (true) {
+        std::string keyValue = toolbox::trim(&attributes, symbols::SEMICOLON);
+        utils::skipSpace(&keyValue);
+        if (keyValue.empty()) {
+            break;
+        }
+        if (keyValue.find("filename=\"") == 0) {
+            std::string filename = keyValue.substr(10);  // "filename=\"" の長さ
+            std::size_t pos = filename.find("\"");
+            if (pos != std::string::npos) {
+                filename.erase(pos);
+                formData.filename = filename;
+            } else {
+                toolbox::logger::StepMark::error("runPost: parseContentDisposition failed: filename is not closed");
+            }
+        } else if (keyValue.find("name=\"") == 0) {
+            std::string name = keyValue.substr(6);  // "name=\"" の長さ
+            std::size_t pos = name.find("\"");
+            if (pos != std::string::npos) {
+                name.erase(pos);
+                formData.name = name;
+            } else {
+                toolbox::logger::StepMark::error("runPost: parseContentDisposition failed: name is not closed");
+            }
+        }
+    }
+}
+
+void parseContentType(std::string& bodyPart, FormDataField& formData) {
+    std::size_t pos = bodyPart.find(symbols::COLON);
+    std::string contentType = bodyPart.substr(pos + 1);
+    if (contentType.empty()) {
+        toolbox::logger::StepMark::error("runPost: parseContentType failed: content type is empty");
+    } else {
+        formData.content_type = contentType;
+    }
+}
+
+void processMultipartBody(const std::string& uploadPath, std::vector<std::string>& bodyParts, const std::string& boundary) {
+    std::string endBoundary = boundary + "--";
+    std::size_t index = 0;
+    std::map<std::string, std::string> formDataMap;
+
+    while(index < bodyParts.size()) {
+        std::string currentLine = bodyParts[index];
+        FormDataField formData;
+
+        while(!currentLine.empty()) {
+            std::size_t crlfPos = currentLine.find(symbols::CRLF);
+            std::size_t lfPos = currentLine.find(symbols::LF);
+            std::size_t pos = std::min(crlfPos, lfPos);
+
+            if (pos == std::string::npos) {
+                toolbox::logger::StepMark::error("runPost: handleMultipartFormData failed: unexpected line");
+                return;
+            }
+
+            std::string line = currentLine.substr(0, pos + utils::getLineEndLen(currentLine, pos));
+            currentLine = currentLine.substr(pos + utils::getLineEndLen(currentLine, pos));
+            // std::cout << "line: " << line << std::endl;
+            // std::cout << "currentLine: " << currentLine << std::endl;
+            if (line.find("Content-Disposition: form-data;") == 0) {
+                parseContentDisposition(line, formData);
+            } else if (line.find("Content-Type:") == 0) {
+                parseContentType(line, formData);
+            } else {  // ""
+                if (line == symbols::CRLF || line == symbols::LF) {
+                    std::cout << "line is empty" << std::endl;
+                    break;
+                }
+                // error
+                toolbox::logger::StepMark::error("runPost: handleMultipartFormData failed: unexpected line");
+                return;
+            }
+        }
+        if (formData.filename.empty()) {
+            // filenameがない場合にはその塊を無視する? 一旦エラー
+            toolbox::logger::StepMark::error("runPost: handleMultipartFormData failed: filename is empty");
+            throw HttpStatus::BAD_REQUEST;
+        }
+
+        if (!formData.filename.empty()) {
+            // std::cout << "formData.filename: " << formData.filename << std::endl;
+            // std::cout << "currentLine: " << currentLine << std::endl;
+            std::size_t lastLfPos = currentLine.find_last_of(symbols::LF);
+            std::size_t lastCrLfPos = currentLine.find_last_of(symbols::CRLF);
+            std::size_t lastNewLinePos = std::max(lastLfPos, lastCrLfPos);
+            std::string content = currentLine.substr(0,lastNewLinePos - 1);
+            // std::cout << "content: " << content << std::endl;
+            formDataMap[formData.filename] += content;
+        }
+        index++;
+    }
+    for (std::map<std::string, std::string>::iterator it = formDataMap.begin(); it != formDataMap.end(); it++) {
+        handleCreateFile(uploadPath, it->first, it->second);
+    }
+}
+ 
+void handleMultipartFormData(const std::string& uploadPath, std::string& recvBody, HTTPFields& fields) {
+    std::string boundary = getBoundary(fields);
+    if (boundary.empty()) {
+        toolbox::logger::StepMark::error("runPost: handleMultipartFormData failed: boundary is empty");
+        throw HttpStatus::BAD_REQUEST;
+    }
+    std::vector<std::string> bodyParts;
+    splitBodyByBoundary(bodyParts, recvBody, boundary);
+
+    processMultipartBody(uploadPath, bodyParts, boundary);
+}
+
+void handleUrlEncoded(const std::string& uploadPath, std::string& recvBody) {
+    std::string body;
+    while (!recvBody.empty()) {
+        std::string keyValue = toolbox::trim(&recvBody, symbols::AMPERSAND);
+        std::size_t equalPos = keyValue.find(symbols::EQUAL);
+        if (equalPos == std::string::npos) {
+            if (!utils::percentDecode(keyValue, &body)) {
+                toolbox::logger::StepMark::error("runPost: handleUrlEncoded failed: " + keyValue);
+                throw HttpStatus::BAD_REQUEST;
+            }
+            body += symbols::EQUAL;
+            body += symbols::LF;
+        } else {
+            std::string key = keyValue.substr(0, equalPos);
+            std::string value = keyValue.substr(equalPos + 1);
+            if (!utils::percentDecode(key, &body)) {
+                toolbox::logger::StepMark::error("runPost: handleUrlEncoded failed: " + key);
+                throw HttpStatus::BAD_REQUEST;
+            }
+            body += symbols::EQUAL;
+            if (!utils::percentDecode(value, &body)) {
+                toolbox::logger::StepMark::error("runPost: handleUrlEncoded failed: " + value);
+                throw HttpStatus::BAD_REQUEST;
+            }
+        }
+        body += symbols::LF;
+    }
+    handleCreateFile(uploadPath, "", body);
+}
+
+void runPost(const std::string& uploadPath, std::string& recvBody, HTTPFields& fields, Response& response) {
+    if (uploadPath.empty()) {
+        handleNonExistUploadPath(response);
+        return;
+    }
+    try {
+        if (isMultipartFormData(fields)) {
+            handleMultipartFormData(uploadPath, recvBody, fields);
+        } else if (isUrlEncoded(fields)) {
+            handleUrlEncoded(uploadPath, recvBody);
+        } else {
+            handleCreateFile(uploadPath, "", recvBody);
+        }
+    } catch (const HttpStatus::EHttpStatus& e) {
+        toolbox::logger::StepMark::error("runPost: setStatus " + toolbox::to_string(static_cast<int>(e)));
+        response.setStatus(e);
+    }
+}
+
+}  // namespace http

--- a/src/http/response/post_method.cpp
+++ b/src/http/response/post_method.cpp
@@ -10,117 +10,145 @@
 
 namespace http {
 namespace {
+
+const char* MULTIPART_FORM_DATA = "multipart/form-data";
+const char* URL_ENCODED = "application/x-www-form-urlencoded";
+const char* CONTENT_DISPOSITION = "Content-Disposition: form-data;";
+const char* const BOUNDARY_PREFIX = "boundary=";
+const size_t BOUNDARY_PREFIX_LEN = 9;
+const char* const FILENAME_PREFIX = "filename=\"";
+const size_t FILENAME_PREFIX_LEN = 10;
+
 bool startsWith(const std::string& str, const std::string& prefix) {
     return str.find(prefix) == 0;
 }
 
-bool isMultipartFormData(HTTPFields& fields) {
-    HTTPFields::FieldValue contentType = fields.getFieldValue(fields::CONTENT_TYPE);
-    return !contentType.empty() && startsWith(contentType[0], "multipart/form-data");
+bool isFileExists(const std::string& name) {
+    struct stat buffer;
+    return (stat(name.c_str(), &buffer) == 0 && S_ISREG(buffer.st_mode));
 }
-
-bool isUrlEncoded(HTTPFields& fields) {
-    HTTPFields::FieldValue contentType = fields.getFieldValue(fields::CONTENT_TYPE);
-    return !contentType.empty() && startsWith(contentType[0], "application/x-www-form-urlencoded");
-}
-
-std::string getBoundary(HTTPFields& fields) {
-    std::string boundary = fields.getFieldValue(fields::CONTENT_TYPE)[0];
-    std::size_t pos = boundary.find("boundary=");
-    if (pos == std::string::npos) {
-        return "";
-    }
-    std::string boundaryStr = boundary.substr(pos + 9);  // "boundary=" len = 9
-    return "--" + boundaryStr;
-}
-
-// void writeToFile(const std::string& filename, const std::string& bodyPart) {
-//     std::ofstream ofs(filename.c_str(), std::ios_base::binary | std::ios_base::app);
-//     if (!ofs) {
-//         toolbox::logger::StepMark::error("runPost: writeToFile failed: " + filename);
-//         throw HttpStatus::INTERNAL_SERVER_ERROR;
-//     }
-//     ofs.write(reinterpret_cast<const char*>(bodyPart.c_str()), bodyPart.size());
-// }
 
 std::string getTimestamp() {
     return toolbox::to_string(time(NULL));
 }
 
-void splitBodyByBoundary(std::vector<std::string>& bodyParts,
-                        std::string& recvBody,
-                        const std::string& boundary) {
-    std::string endBoundary = boundary + "--";
-    std::size_t pos = 0;
-    
-    while (pos < recvBody.length()) {
-        // Find the next boundary
-        std::size_t boundaryPos = recvBody.find(boundary, pos);
-        if (boundaryPos == std::string::npos) {
-            break;
-        }
-        
-        // Skip the boundary and any following newlines
-        pos = boundaryPos + boundary.length();
-        while (pos < recvBody.length() && 
-               (recvBody[pos] == '\r' || recvBody[pos] == '\n')) {
-            pos++;
-        }
-        
-        // Find the next boundary or end boundary
-        std::size_t nextBoundaryPos = recvBody.find(boundary, pos);
-        if (nextBoundaryPos == std::string::npos) {
-            nextBoundaryPos = recvBody.find(endBoundary, pos);
-            if (nextBoundaryPos == std::string::npos) {
-                break;
-            }
-        }
-        
-        // Extract the part between boundaries
-        std::string part = recvBody.substr(pos, nextBoundaryPos - pos);
-        if (!part.empty()) {
-            bodyParts.push_back(part);
-        }
-        
-        pos = nextBoundaryPos;
+void saveToFile(const std::string& filepath, const std::string& content) {
+    std::ofstream ofs(filepath.c_str(), std::ios::binary);
+    if (!ofs) {
+        toolbox::logger::StepMark::error("runPost: saveToFile failed: " + filepath);
+        throw HttpStatus::INTERNAL_SERVER_ERROR;
     }
+    ofs.write(content.data(), content.size());
+    if (ofs.fail()) {
+        toolbox::logger::StepMark::error("runPost: saveToFile failed: " + filepath);
+        throw HttpStatus::INTERNAL_SERVER_ERROR;
+    }
+    toolbox::logger::StepMark::info("runPost: file created: " + filepath);
 }
 
-}  // namespace
+// Content type handling
+bool isMultipartFormData(HTTPFields::FieldValue& contentType) {
+    return !contentType.empty() && startsWith(contentType[0], MULTIPART_FORM_DATA);
+}
 
-void handleCreateFile(const std::string& uploadPath, std::string filename, const std::string& body) {
-    std::cout << "handleCreateFile: " << filename << std::endl;
+bool isUrlEncoded(HTTPFields::FieldValue& contentType) {
+    return !contentType.empty() && startsWith(contentType[0], URL_ENCODED);
+}
+
+std::string getBoundary(HTTPFields& fields) {
+    HTTPFields::FieldValue contentType = fields.getFieldValue(fields::CONTENT_TYPE);
+    if (contentType.empty()) {
+        toolbox::logger::StepMark::error("runPost: getBoundary failed: contentType is empty");
+        return "";
+    }
+    std::string contentTypeStr = contentType[0];
+    std::size_t boundaryPos = contentTypeStr.find(BOUNDARY_PREFIX);
+    if (boundaryPos == std::string::npos) {
+        toolbox::logger::StepMark::error("runPost: getBoundary failed: boundary is not found");
+        return "";
+    }
+    std::string boundaryStr = contentTypeStr.substr(boundaryPos + BOUNDARY_PREFIX_LEN);
+    return "--" + boundaryStr;
+}
+
+std::string generateUniqueFilename(const std::string& uploadPath, const std::string& baseFilename) {
+    std::string filename = baseFilename;
+    std::string name, extension;
+    std::size_t dotPos = filename.find_last_of('.');
+
+    if (dotPos != std::string::npos) {
+        name = filename.substr(0, dotPos);
+        extension = filename.substr(dotPos);
+    } else {
+        name = filename;
+        extension = "";
+    }
+
+    std::size_t counter = 1;
+    while (isFileExists(joinPath(uploadPath, filename))) {
+        filename = name + "(" + toolbox::to_string(counter) + ")" + extension;
+        counter++;
+    }
+    return filename;
+}
+
+void handleCreateFile(const std::string& uploadPath, std::string filename, const std::string& content, HTTPFields& fields) {
     if (filename.empty()) {
         filename = getTimestamp();
     }
-    std::string filepath = joinPath(uploadPath, filename);
-    std::ofstream ofs(filepath.c_str(), std::ios::binary);
-    if (!ofs) {
-        toolbox::logger::StepMark::error("runPost: handleCreateFile failed: " + filepath);
-        throw HttpStatus::INTERNAL_SERVER_ERROR;
+    if (filename.find('.') == std::string::npos) {
+        HTTPFields::FieldValue contentType = fields.getFieldValue(fields::CONTENT_TYPE);
+        if (!contentType.empty()) {
+            std::string extension = ContentTypeManager::getExtension(contentType[0]);
+            if (!extension.empty()) {
+                filename += "." + extension;
+            }
+        }
     }
-    ofs.write(body.data(), body.size());
+    std::string filepath = joinPath(uploadPath, filename);
+    if (isFileExists(filepath)) {
+        filename = generateUniqueFilename(uploadPath, filename);
+        filepath = joinPath(uploadPath, filename);
+    }
+
+    saveToFile(filepath, content);
 }
 
-void handleNonExistUploadPath(Response& response) {
-    response.setBody("Upload path does not exist");
-    response.setStatus(HttpStatus::NOT_IMPLEMENTED);
+// Multipart form data parsing
+void extractMultipartSegments(std::vector<std::string>& bodyParts,
+                              std::string& recvBody,
+                              const std::string& boundary) {
+    std::string endBoundary = symbols::CRLF + boundary + "--";
+    std::size_t boundaryPos = 0;
+
+    boundaryPos = recvBody.find(boundary, boundaryPos);
+    boundaryPos += boundary.length();
+    while (boundaryPos < recvBody.length()) {
+        std::size_t nextBoundaryPos = recvBody.find(symbols::CRLF + boundary, boundaryPos);
+        if (nextBoundaryPos == std::string::npos) {
+            return;
+        }
+
+        std::string part = recvBody.substr(boundaryPos + std::string(symbols::CRLF).length(), nextBoundaryPos - boundaryPos);
+        bodyParts.push_back(part);
+
+        if (recvBody.find(endBoundary, nextBoundaryPos) == nextBoundaryPos) {
+            break;
+        }
+        boundaryPos = nextBoundaryPos + std::string(symbols::CRLF).length() + boundary.length();
+    }
 }
 
 void parseContentDisposition(std::string& bodyPart, FormDataField& formData) {
-    std::size_t pos = bodyPart.find("Content-Disposition: form-data;");
-    if (pos == std::string::npos) {
-        return;
-    }
-    std::string attributes = bodyPart.substr(pos + 31);  // "Content-Disposition: form-data;" の長さ
+    std::string attributes = bodyPart.substr(std::string(CONTENT_DISPOSITION).length());
     while (true) {
         std::string keyValue = toolbox::trim(&attributes, symbols::SEMICOLON);
         utils::skipSpace(&keyValue);
         if (keyValue.empty()) {
             break;
         }
-        if (keyValue.find("filename=\"") == 0) {
-            std::string filename = keyValue.substr(10);  // "filename=\"" の長さ
+        if (keyValue.find(FILENAME_PREFIX) == 0) {
+            std::string filename = keyValue.substr(FILENAME_PREFIX_LEN);
             std::size_t pos = filename.find("\"");
             if (pos != std::string::npos) {
                 filename.erase(pos);
@@ -128,102 +156,68 @@ void parseContentDisposition(std::string& bodyPart, FormDataField& formData) {
             } else {
                 toolbox::logger::StepMark::error("runPost: parseContentDisposition failed: filename is not closed");
             }
-        } else if (keyValue.find("name=\"") == 0) {
-            std::string name = keyValue.substr(6);  // "name=\"" の長さ
-            std::size_t pos = name.find("\"");
-            if (pos != std::string::npos) {
-                name.erase(pos);
-                formData.name = name;
-            } else {
-                toolbox::logger::StepMark::error("runPost: parseContentDisposition failed: name is not closed");
-            }
         }
     }
 }
 
-void parseContentType(std::string& bodyPart, FormDataField& formData) {
-    std::size_t pos = bodyPart.find(symbols::COLON);
-    std::string contentType = bodyPart.substr(pos + 1);
-    if (contentType.empty()) {
-        toolbox::logger::StepMark::error("runPost: parseContentType failed: content type is empty");
-    } else {
-        formData.content_type = contentType;
+void extractPartData(std::string& currentLine, FormDataField& formData) {
+    while (!currentLine.empty()) {
+        std::size_t crlfPos = currentLine.find(symbols::CRLF);
+        if (crlfPos == std::string::npos) {
+            toolbox::logger::StepMark::error("runPost: handleMultipartFormData failed: unexpected line");
+            return;
+        }
+        std::string line = toolbox::trim(&currentLine, symbols::CRLF);
+        if (line.empty()) {
+            break;
+        }
+
+        if (line.find(CONTENT_DISPOSITION) == 0) {
+            parseContentDisposition(line, formData);
+        }
     }
 }
 
-void processMultipartBody(const std::string& uploadPath, std::vector<std::string>& bodyParts, const std::string& boundary) {
-    std::string endBoundary = boundary + "--";
-    std::size_t index = 0;
-    std::map<std::string, std::string> formDataMap;
-
-    while(index < bodyParts.size()) {
-        std::string currentLine = bodyParts[index];
+void parseMultipartFormData(std::string& recvBody, const std::string& boundary, std::vector<FormDataField>& formDataVec) {
+    std::vector<std::string> bodyParts;
+    extractMultipartSegments(bodyParts, recvBody, boundary);
+    formDataVec.reserve(bodyParts.size());
+    for (std::size_t i = 0; i < bodyParts.size(); i++) {
+        std::string currentLine = bodyParts[i];
         FormDataField formData;
 
-        while(!currentLine.empty()) {
-            std::size_t crlfPos = currentLine.find(symbols::CRLF);
-            std::size_t lfPos = currentLine.find(symbols::LF);
-            std::size_t pos = std::min(crlfPos, lfPos);
-
-            if (pos == std::string::npos) {
-                toolbox::logger::StepMark::error("runPost: handleMultipartFormData failed: unexpected line");
-                return;
-            }
-
-            std::string line = currentLine.substr(0, pos + utils::getLineEndLen(currentLine, pos));
-            currentLine = currentLine.substr(pos + utils::getLineEndLen(currentLine, pos));
-            // std::cout << "line: " << line << std::endl;
-            // std::cout << "currentLine: " << currentLine << std::endl;
-            if (line.find("Content-Disposition: form-data;") == 0) {
-                parseContentDisposition(line, formData);
-            } else if (line.find("Content-Type:") == 0) {
-                parseContentType(line, formData);
-            } else {  // ""
-                if (line == symbols::CRLF || line == symbols::LF) {
-                    std::cout << "line is empty" << std::endl;
-                    break;
-                }
-                // error
-                toolbox::logger::StepMark::error("runPost: handleMultipartFormData failed: unexpected line");
-                return;
-            }
-        }
-        if (formData.filename.empty()) {
-            // filenameがない場合にはその塊を無視する? 一旦エラー
-            toolbox::logger::StepMark::error("runPost: handleMultipartFormData failed: filename is empty");
-            throw HttpStatus::BAD_REQUEST;
-        }
-
-        if (!formData.filename.empty()) {
-            // std::cout << "formData.filename: " << formData.filename << std::endl;
-            // std::cout << "currentLine: " << currentLine << std::endl;
-            std::size_t lastLfPos = currentLine.find_last_of(symbols::LF);
-            std::size_t lastCrLfPos = currentLine.find_last_of(symbols::CRLF);
-            std::size_t lastNewLinePos = std::max(lastLfPos, lastCrLfPos);
-            std::string content = currentLine.substr(0,lastNewLinePos - 1);
-            // std::cout << "content: " << content << std::endl;
-            formDataMap[formData.filename] += content;
-        }
-        index++;
-    }
-    for (std::map<std::string, std::string>::iterator it = formDataMap.begin(); it != formDataMap.end(); it++) {
-        handleCreateFile(uploadPath, it->first, it->second);
+        extractPartData(currentLine, formData);
+        formData.content = currentLine.substr(0, currentLine.length() - std::string(symbols::CRLF).length());
+        formDataVec.push_back(formData);
     }
 }
- 
+
+void connectFormData(std::vector<FormDataField>& formDataVec, std::map<std::string, std::string>& formDataMap) {
+    for (std::vector<FormDataField>::iterator it = formDataVec.begin(); it != formDataVec.end(); it++) {
+        if (!it->filename.empty()) {
+            formDataMap[it->filename] += it->content;
+        }
+    }
+}
+
 void handleMultipartFormData(const std::string& uploadPath, std::string& recvBody, HTTPFields& fields) {
     std::string boundary = getBoundary(fields);
     if (boundary.empty()) {
         toolbox::logger::StepMark::error("runPost: handleMultipartFormData failed: boundary is empty");
         throw HttpStatus::BAD_REQUEST;
     }
-    std::vector<std::string> bodyParts;
-    splitBodyByBoundary(bodyParts, recvBody, boundary);
 
-    processMultipartBody(uploadPath, bodyParts, boundary);
+    std::vector<FormDataField> formDataVec;
+    parseMultipartFormData(recvBody, boundary, formDataVec);
+
+    std::map<std::string, std::string> formDataMap;
+    connectFormData(formDataVec, formDataMap);
+    for (std::map<std::string, std::string>::iterator it = formDataMap.begin(); it != formDataMap.end(); it++) {
+        handleCreateFile(uploadPath, it->first, it->second, fields);
+    }
 }
 
-void handleUrlEncoded(const std::string& uploadPath, std::string& recvBody) {
+void handleUrlEncoded(const std::string& uploadPath, std::string& recvBody, HTTPFields& fields) {
     std::string body;
     while (!recvBody.empty()) {
         std::string keyValue = toolbox::trim(&recvBody, symbols::AMPERSAND);
@@ -250,21 +244,25 @@ void handleUrlEncoded(const std::string& uploadPath, std::string& recvBody) {
         }
         body += symbols::LF;
     }
-    handleCreateFile(uploadPath, "", body);
+    handleCreateFile(uploadPath, "", body, fields);
 }
+
+}  // namespace
 
 void runPost(const std::string& uploadPath, std::string& recvBody, HTTPFields& fields, Response& response) {
     if (uploadPath.empty()) {
-        handleNonExistUploadPath(response);
+        toolbox::logger::StepMark::error("runPost: uploadPath is empty");
+        response.setStatus(HttpStatus::NOT_IMPLEMENTED);
         return;
     }
     try {
-        if (isMultipartFormData(fields)) {
+        HTTPFields::FieldValue contentType = fields.getFieldValue(fields::CONTENT_TYPE);
+        if (isMultipartFormData(contentType)) {
             handleMultipartFormData(uploadPath, recvBody, fields);
-        } else if (isUrlEncoded(fields)) {
-            handleUrlEncoded(uploadPath, recvBody);
+        } else if (isUrlEncoded(contentType)) {
+            handleUrlEncoded(uploadPath, recvBody, fields);
         } else {
-            handleCreateFile(uploadPath, "", recvBody);
+            handleCreateFile(uploadPath, "", recvBody, fields);
         }
     } catch (const HttpStatus::EHttpStatus& e) {
         toolbox::logger::StepMark::error("runPost: setStatus " + toolbox::to_string(static_cast<int>(e)));

--- a/src/http/response/post_method.cpp
+++ b/src/http/response/post_method.cpp
@@ -264,6 +264,7 @@ void runPost(const std::string& uploadPath, std::string& recvBody, HTTPFields& f
         toolbox::logger::StepMark::error("runPost: setStatus " + toolbox::to_string(static_cast<int>(e)));
         response.setStatus(e);
     }
+    response.setStatus(HttpStatus::CREATED);
 }
 
 }  // namespace http

--- a/src/http/response/post_method.cpp
+++ b/src/http/response/post_method.cpp
@@ -246,12 +246,12 @@ void handleUrlEncoded(const std::string& uploadPath, std::string& recvBody, HTTP
 }  // namespace
 
 void runPost(const std::string& uploadPath, std::string& recvBody, HTTPFields& fields, Response& response) {
-    if (uploadPath.empty()) {
-        toolbox::logger::StepMark::error("runPost: uploadPath is empty");
-        response.setStatus(HttpStatus::NOT_IMPLEMENTED);
-        return;
-    }
     try {
+        if (uploadPath.empty()) {
+            toolbox::logger::StepMark::error("runPost: uploadPath is empty");
+            throw HttpStatus::NOT_IMPLEMENTED;
+        }
+
         HTTPFields::FieldValue contentType = fields.getFieldValue(fields::CONTENT_TYPE);
         if (isMultipartFormData(contentType)) {
             handleMultipartFormData(uploadPath, recvBody, fields);
@@ -260,11 +260,11 @@ void runPost(const std::string& uploadPath, std::string& recvBody, HTTPFields& f
         } else {
             handleCreateFile(uploadPath, "", recvBody, fields);
         }
+        response.setStatus(HttpStatus::CREATED);
     } catch (const HttpStatus::EHttpStatus& e) {
         toolbox::logger::StepMark::error("runPost: setStatus " + toolbox::to_string(static_cast<int>(e)));
         response.setStatus(e);
     }
-    response.setStatus(HttpStatus::CREATED);
 }
 
 }  // namespace http

--- a/src/http/response/post_method.cpp
+++ b/src/http/response/post_method.cpp
@@ -46,7 +46,6 @@ void saveToFile(const std::string& filepath, const std::string& content) {
     toolbox::logger::StepMark::info("runPost: file created: " + filepath);
 }
 
-// Content type handling
 bool isMultipartFormData(HTTPFields::FieldValue& contentType) {
     return !contentType.empty() && startsWith(contentType[0], MULTIPART_FORM_DATA);
 }
@@ -114,10 +113,7 @@ void handleCreateFile(const std::string& uploadPath, std::string filename, const
     saveToFile(filepath, content);
 }
 
-// Multipart form data parsing
-void extractMultipartSegments(std::vector<std::string>& bodyParts,
-                              std::string& recvBody,
-                              const std::string& boundary) {
+void extractMultipartSegments(std::vector<std::string>& bodyParts, const std::string& recvBody, const std::string& boundary) {
     std::string endBoundary = symbols::CRLF + boundary + "--";
     std::size_t boundaryPos = 0;
 

--- a/src/http/response/post_method.cpp
+++ b/src/http/response/post_method.cpp
@@ -98,7 +98,7 @@ void handleCreateFile(const std::string& uploadPath, std::string filename, const
     if (filename.find('.') == std::string::npos) {
         HTTPFields::FieldValue contentType = fields.getFieldValue(fields::CONTENT_TYPE);
         if (!contentType.empty()) {
-            std::string extension = ContentTypeManager::getExtension(contentType[0]);
+            std::string extension = ContentTypeManager::getInstance().getExtension(contentType[0]);
             if (!extension.empty()) {
                 filename += "." + extension;
             }

--- a/src/http/response/post_method.hpp
+++ b/src/http/response/post_method.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+
+#include "../../../toolbox/string.hpp"
+#include "../request/http_fields.hpp"
+#include "../http_status.hpp"
+#include "../http_namespace.hpp"
+#include "response.hpp"
+#include "method_utils.hpp"
+
+namespace http {
+struct FormDataField {
+    std::string name;
+    std::string filename;
+    std::string content_type;
+};
+
+void runPost(const std::string& uploadPath, std::string& recvBody, HTTPFields& fields, Response& response);
+}

--- a/src/http/response/post_method.hpp
+++ b/src/http/response/post_method.hpp
@@ -8,12 +8,12 @@
 #include "../http_namespace.hpp"
 #include "response.hpp"
 #include "method_utils.hpp"
+#include "content_type_manager.hpp"
 
 namespace http {
 struct FormDataField {
-    std::string name;
     std::string filename;
-    std::string content_type;
+    std::string content;
 };
 
 void runPost(const std::string& uploadPath, std::string& recvBody, HTTPFields& fields, Response& response);

--- a/src/http/string_utils.cpp
+++ b/src/http/string_utils.cpp
@@ -61,8 +61,8 @@ std::string decodeHex(const std::string& hexStr) {
     }
 
     char* endptr = NULL;
-    std::size_t hex = strtol(hexStr.c_str(), &endptr, 16);
-    if (*endptr != '\0' || hex < 1 || hex > 255) {
+    std::size_t hex = strtoul(hexStr.c_str(), &endptr, 16);
+    if (*endptr != '\0' || hex > 255) {
         return "";
     }
     return std::string(1, static_cast<char>(hex));

--- a/src/http/string_utils.cpp
+++ b/src/http/string_utils.cpp
@@ -1,5 +1,4 @@
 #include <string>
-#include <iostream>
 
 #include "string_utils.hpp"
 
@@ -51,15 +50,6 @@ void skipSpace(std::string* line) {
     *line = line->substr(not_sp_pos);
 }
 
-std::size_t getLineEndLen(std::string& line, std::size_t lineEndPos) {
-    if (line.find(symbols::CRLF) == lineEndPos) {
-        return 2;
-    } else if (line.find(symbols::LF) == lineEndPos) {
-        return 1;
-    }
-    return 0;
-}
-
 bool isEqualCaseInsensitive(const std::string& str1, const std::string& str2) {
     CaseInsensitiveLess less;
     return !less(str1, str2) && !less(str2, str1);
@@ -70,17 +60,18 @@ std::string decodeHex(const std::string& hexStr) {
         return "";
     }
 
-    std::string decodedStr;
     char* endptr = NULL;
     std::size_t hex = strtol(hexStr.c_str(), &endptr, 16);
-    decodedStr = static_cast<char>(hex);
-    if (*endptr != '\0' || hex == '\0') {
+    if (*endptr != '\0' || hex < 1 || hex > 255) {
         return "";
     }
-    return decodedStr;
+    return std::string(1, static_cast<char>(hex));
 }
 
 bool percentDecode(std::string& str, std::string* buf) {
+    if (buf == NULL) {
+        return false;
+    }
     std::size_t pos = str.find(symbols::PERCENT);
     if (pos == std::string::npos) {
         *buf += str;

--- a/src/http/string_utils.hpp
+++ b/src/http/string_utils.hpp
@@ -1,6 +1,8 @@
 #include <string>
 #include <cctype>
+#include <cstdlib>
 
+#include "../../toolbox/stepmark.hpp"
 #include "../../toolbox/string.hpp"
 #include "http_namespace.hpp"
 #include "case_insensitive_less.hpp"
@@ -14,8 +16,10 @@ bool isDigitStr(const std::string& str);
 bool isAlnumStr(const std::string& str);
 void trimSpace(std::string* str);
 void skipSpace(std::string* line);
+std::size_t getLineEndLen(std::string& line, std::size_t lineEndPos);
 bool isEqualCaseInsensitive(
         const std::string& str1, const std::string& str2);
+bool percentDecode(std::string& str, std::string* buf);
 
 }  // namespace utils
 }  // namespace http

--- a/src/http/string_utils.hpp
+++ b/src/http/string_utils.hpp
@@ -16,7 +16,6 @@ bool isDigitStr(const std::string& str);
 bool isAlnumStr(const std::string& str);
 void trimSpace(std::string* str);
 void skipSpace(std::string* line);
-std::size_t getLineEndLen(std::string& line, std::size_t lineEndPos);
 bool isEqualCaseInsensitive(
         const std::string& str1, const std::string& str2);
 bool percentDecode(std::string& str, std::string* buf);

--- a/test/http/response/.gitignore
+++ b/test/http/response/.gitignore
@@ -1,2 +1,3 @@
 response_test
 method_test
+uploads

--- a/test/http/response/method/Makefile
+++ b/test/http/response/method/Makefile
@@ -8,7 +8,8 @@ SRCS = main.cpp get.cpp head.cpp post.cpp \
 ../../../../src/http/http_namespace.cpp \
 ../../../../src/http/response/response.cpp \
 ../../../../src/http/response/post_method.cpp \
-../../../../src/http/string_utils.cpp
+../../../../src/http/string_utils.cpp \
+../../../../src/http/response/content_type_manager.cpp
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/test/http/response/method/Makefile
+++ b/test/http/response/method/Makefile
@@ -1,11 +1,14 @@
 NAME = method_test
-SRCS = main.cpp get.cpp head.cpp ../../../../src/http/response/get_method.cpp \
+SRCS = main.cpp get.cpp head.cpp post.cpp \
+../../../../src/http/response/get_method.cpp \
 ../../../../toolbox/stepmark.cpp ../../../../toolbox/string.cpp \
 ../../../../src/http/response/method_utils.cpp \
 ../../../../src/http/response/head_method.cpp \
 ../../../../src/http/request/http_fields.cpp \
 ../../../../src/http/http_namespace.cpp \
 ../../../../src/http/response/response.cpp \
+../../../../src/http/response/post_method.cpp \
+../../../../src/http/string_utils.cpp
 
 OBJS = $(SRCS:.cpp=.o)
 
@@ -24,6 +27,9 @@ clean:
 
 fclean: clean
 	$(RM) $(NAME)
+	$(RM) stepmark.log
+	$(RM) post_test.log
+	$(RM) -rf uploads
 
 re: fclean all
 

--- a/test/http/response/method/delete.cpp
+++ b/test/http/response/method/delete.cpp
@@ -47,8 +47,6 @@ static void cleanupTestEnvironment() {
 }
 
 static void runTests() {
-    http::ExtensionMap extensionMap;
-    http::initExtensionMap(extensionMap);
     http::Response response;
 
     std::string path = "./test_dir/test.html";

--- a/test/http/response/method/delete.cpp
+++ b/test/http/response/method/delete.cpp
@@ -50,27 +50,19 @@ static void runTests() {
     http::Response response;
 
     std::string path = "./test_dir/test.html";
-    toolbox::logger::StepMark::info("===== delete normal file =====");
-    toolbox::logger::StepMark::info("except status: " +
-        toolbox::to_string(http::HttpStatus::NO_CONTENT));
+    toolbox::logger::StepMark::info("==== [DELETE] SUCCESS:204 normal file ====");
     http::runDelete(path, response);
 
     path = "./test_dir/nonexistent.html";
-    toolbox::logger::StepMark::info("===== delete nonexistent file =====");
-    toolbox::logger::StepMark::info("except status: " +
-        toolbox::to_string(http::HttpStatus::NOT_FOUND));
+    toolbox::logger::StepMark::info("==== [DELETE] FAIL:404 nonexistent file ====");
     http::runDelete(path, response);
 
     path = "./test_dir/no_permission.html";
-    toolbox::logger::StepMark::info("===== delete no_permission file =====");
-    toolbox::logger::StepMark::info("except status: " +
-        toolbox::to_string(http::HttpStatus::FORBIDDEN));
+    toolbox::logger::StepMark::info("==== [DELETE] FAIL:403 no permission file ====");
     http::runDelete(path, response);
 
     path = "./test_dir";
-    toolbox::logger::StepMark::info("===== delete dir =====");
-    toolbox::logger::StepMark::info("except status: " +
-        toolbox::to_string(http::HttpStatus::FORBIDDEN));
+    toolbox::logger::StepMark::info("==== [DELETE] FAIL:403 dir ====");
     http::runDelete(path, response);
 }
 

--- a/test/http/response/method/get.cpp
+++ b/test/http/response/method/get.cpp
@@ -47,57 +47,47 @@ static void cleanupTestEnvironment() {
 }
 
 static void runTests() {
-    http::ExtensionMap extensionMap;
-    http::initExtensionMap(extensionMap);
     http::HttpStatus::EHttpStatus status;
     http::Response response;
 
     std::cout << "===== get nomal file =====" << std::endl;
-    status = http::runGet("./test_dir/test.html", "", false,
-        extensionMap, response);
+    status = http::runGet("./test_dir/test.html", "", false, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get nonexistent file =====" << std::endl;
-    status = runGet("./test_dir/nonexistent.html", "", false,
-        extensionMap, response);
+    status = http::runGet("./test_dir/nonexistent.html", "", false, response);
     assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get dir indexfile =====" << std::endl;
-    status = runGet("./test_dir/", "index.html", false,
-        extensionMap, response);
+    status = http::runGet("./test_dir/", "index.html", false, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get dir autoindex =====" << std::endl;
-    status = runGet("./test_dir/", "", true,
-        extensionMap, response);
+    status = http::runGet("./test_dir/", "", true, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get no permission =====" << std::endl;
-    status = runGet("./test_dir/no_permission.html", "", false,
-        extensionMap, response);
+    status = http::runGet("./test_dir/no_permission.html", "", false, response);
     assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get empty dir ====="
         << std::endl;
-    status = runGet("./test_dir/empty_dir/", "", true,
-        extensionMap, response);
+    status = http::runGet("./test_dir/empty_dir/", "", true, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get empty dir indexfile =====" << std::endl;
-    status = runGet("./test_dir/empty_dir/", "index.html",
-        false, extensionMap, response);
+    status = http::runGet("./test_dir/empty_dir/", "index.html", false, response);
     assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== get no permission dir =====" << std::endl;
-    status = runGet("./test_dir/no_permission_dir/", "",
-        true, extensionMap, response);
+    status = http::runGet("./test_dir/no_permission_dir/", "", true, response);
     assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 }

--- a/test/http/response/method/get.cpp
+++ b/test/http/response/method/get.cpp
@@ -50,7 +50,7 @@ static void cleanupTestEnvironment() {
 static void runTests() {
     http::Response response;
 
-    toolbox::logger::StepMark::info("==== [GET] SUCCESS:200 nomal file =====");
+    toolbox::logger::StepMark::info("==== [GET] SUCCESS:200 normal file =====");
     http::runGet("./test_dir/test.html", "", false, response);
 
     toolbox::logger::StepMark::info("==== [GET] FAIL:404 nonexistent file =====");

--- a/test/http/response/method/get.cpp
+++ b/test/http/response/method/get.cpp
@@ -13,6 +13,7 @@
 #include "../../../../src/http/case_insensitive_less.hpp"
 #include "../../../../src/http/response/get_method.hpp"
 #include "../../../../src/http/response/response.hpp"
+#include "../../../../toolbox/stepmark.hpp"
 
 static void setupTestEnvironment() {
     mkdir("./test_dir", 0755);
@@ -47,49 +48,31 @@ static void cleanupTestEnvironment() {
 }
 
 static void runTests() {
-    http::HttpStatus::EHttpStatus status;
     http::Response response;
 
-    std::cout << "===== get nomal file =====" << std::endl;
-    status = http::runGet("./test_dir/test.html", "", false, response);
-    assert(status == http::HttpStatus::OK);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [GET] SUCCESS:200 nomal file =====");
+    http::runGet("./test_dir/test.html", "", false, response);
 
-    std::cout << "===== get nonexistent file =====" << std::endl;
-    status = http::runGet("./test_dir/nonexistent.html", "", false, response);
-    assert(status == http::HttpStatus::NOT_FOUND);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [GET] FAIL:404 nonexistent file =====");
+    http::runGet("./test_dir/nonexistent.html", "", false, response);
 
-    std::cout << "===== get dir indexfile =====" << std::endl;
-    status = http::runGet("./test_dir/", "index.html", false, response);
-    assert(status == http::HttpStatus::OK);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [GET] SUCCESS:200 dir indexfile =====");
+    http::runGet("./test_dir/", "index.html", false, response);
 
-    std::cout << "===== get dir autoindex =====" << std::endl;
-    status = http::runGet("./test_dir/", "", true, response);
-    assert(status == http::HttpStatus::OK);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [GET] SUCCESS:200 dir autoindex =====");
+    http::runGet("./test_dir/", "", true, response);
 
-    std::cout << "===== get no permission =====" << std::endl;
-    status = http::runGet("./test_dir/no_permission.html", "", false, response);
-    assert(status == http::HttpStatus::FORBIDDEN);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [GET] FAIL:403 no permission file =====");
+    http::runGet("./test_dir/no_permission.html", "", false, response);
 
-    std::cout << "===== get empty dir ====="
-        << std::endl;
-    status = http::runGet("./test_dir/empty_dir/", "", true, response);
-    assert(status == http::HttpStatus::OK);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [GET] SUCCESS:200 empty dir =====");
+    http::runGet("./test_dir/empty_dir/", "", true, response);
 
-    std::cout << "===== get empty dir indexfile =====" << std::endl;
-    status = http::runGet("./test_dir/empty_dir/", "index.html", false, response);
-    assert(status == http::HttpStatus::NOT_FOUND);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [GET] FAIL:404 empty dir indexfile =====");
+    http::runGet("./test_dir/empty_dir/", "index.html", false, response);
 
-    std::cout << "===== get no permission dir =====" << std::endl;
-    status = http::runGet("./test_dir/no_permission_dir/", "", true, response);
-    assert(status == http::HttpStatus::FORBIDDEN);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [GET] FAIL:403 no permission dir =====");
+    http::runGet("./test_dir/no_permission_dir/", "", true, response);
 }
 
 void get_test() {

--- a/test/http/response/method/head.cpp
+++ b/test/http/response/method/head.cpp
@@ -50,57 +50,47 @@ static void cleanupTestEnvironment() {
 }
 
 static void runTests() {
-    http::ExtensionMap extensionMap;
-    http::initExtensionMap(extensionMap);
     http::HttpStatus::EHttpStatus status;
     http::Response response;
 
     std::cout << "===== head normal file (modified time) =====" << std::endl;
-    status = http::runHead("./test_dir/test.html", "", false,
-        extensionMap, response);
+    status = http::runHead("./test_dir/test.html", "", false, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== head nonexistent file =====" << std::endl;
-    status = http::runHead("./test_dir/nonexistent.html", "", false,
-        extensionMap, response);
+    status = http::runHead("./test_dir/nonexistent.html", "", false, response);
     assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== head dir indexfile (modified time) =====" << std::endl;
-    status = http::runHead("./test_dir/", "index.html", false,
-        extensionMap, response);
+    status = http::runHead("./test_dir/", "index.html", false, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== head dir autoindex =====" << std::endl;
-    status = http::runHead("./test_dir/", "", true,
-        extensionMap, response);
+    status = http::runHead("./test_dir/", "", true, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== head no permission =====" << std::endl;
-    status = http::runHead("./test_dir/no_permission.html", "",
-        false, extensionMap, response);
+    status = http::runHead("./test_dir/no_permission.html", "", false, response);
     assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== head empty dir ====="
         << std::endl;
-    status = http::runHead("./test_dir/empty_dir/", "",
-        true, extensionMap, response);
+    status = http::runHead("./test_dir/empty_dir/", "", true, response);
     assert(status == http::HttpStatus::OK);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== head empty dir indexfile =====" << std::endl;
-    status = http::runHead("./test_dir/empty_dir/", "index.html",
-        false, extensionMap, response);
+    status = http::runHead("./test_dir/empty_dir/", "index.html", false, response);
     assert(status == http::HttpStatus::NOT_FOUND);
     std::cout << "OK: " << status << std::endl;
 
     std::cout << "===== head no permission dir =====" << std::endl;
-    status = http::runHead("./test_dir/no_permission_dir/", "",
-        true, extensionMap, response);
+    status = http::runHead("./test_dir/no_permission_dir/", "", true, response);
     assert(status == http::HttpStatus::FORBIDDEN);
     std::cout << "OK: " << status << std::endl;
 }

--- a/test/http/response/method/head.cpp
+++ b/test/http/response/method/head.cpp
@@ -16,6 +16,7 @@
 #include "../../../../src/http/response/head_method.hpp"
 #include "../../../../src/http/response/response.hpp"
 #include "../../../../src/http/http_namespace.hpp"
+#include "../../../../toolbox/stepmark.hpp"
 
 static void setupTestEnvironment() {
     mkdir("./test_dir", 0755);
@@ -50,49 +51,31 @@ static void cleanupTestEnvironment() {
 }
 
 static void runTests() {
-    http::HttpStatus::EHttpStatus status;
     http::Response response;
 
-    std::cout << "===== head normal file (modified time) =====" << std::endl;
-    status = http::runHead("./test_dir/test.html", "", false, response);
-    assert(status == http::HttpStatus::OK);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [HEAD] SUCCESS:200 normal file ====");
+    http::runHead("./test_dir/test.html", "", false, response);
 
-    std::cout << "===== head nonexistent file =====" << std::endl;
-    status = http::runHead("./test_dir/nonexistent.html", "", false, response);
-    assert(status == http::HttpStatus::NOT_FOUND);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [HEAD] FAIL:404 nonexistent file ====");
+    http::runHead("./test_dir/nonexistent.html", "", false, response);
 
-    std::cout << "===== head dir indexfile (modified time) =====" << std::endl;
-    status = http::runHead("./test_dir/", "index.html", false, response);
-    assert(status == http::HttpStatus::OK);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [HEAD] SUCCESS:200 dir indexfile (modified time) ====");
+    http::runHead("./test_dir/", "index.html", false, response);
 
-    std::cout << "===== head dir autoindex =====" << std::endl;
-    status = http::runHead("./test_dir/", "", true, response);
-    assert(status == http::HttpStatus::OK);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [HEAD] SUCCESS:200 dir autoindex ====");
+    http::runHead("./test_dir/", "", true, response);
 
-    std::cout << "===== head no permission =====" << std::endl;
-    status = http::runHead("./test_dir/no_permission.html", "", false, response);
-    assert(status == http::HttpStatus::FORBIDDEN);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [HEAD] FAIL:403 no permission ====");
+    http::runHead("./test_dir/no_permission.html", "", false, response);
 
-    std::cout << "===== head empty dir ====="
-        << std::endl;
-    status = http::runHead("./test_dir/empty_dir/", "", true, response);
-    assert(status == http::HttpStatus::OK);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [HEAD] SUCCESS:200 empty dir ====");
+    http::runHead("./test_dir/empty_dir/", "", true, response);
 
-    std::cout << "===== head empty dir indexfile =====" << std::endl;
-    status = http::runHead("./test_dir/empty_dir/", "index.html", false, response);
-    assert(status == http::HttpStatus::NOT_FOUND);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [HEAD] FAIL:404 empty dir indexfile ====");
+    http::runHead("./test_dir/empty_dir/", "index.html", false, response);
 
-    std::cout << "===== head no permission dir =====" << std::endl;
-    status = http::runHead("./test_dir/no_permission_dir/", "", true, response);
-    assert(status == http::HttpStatus::FORBIDDEN);
-    std::cout << "OK: " << status << std::endl;
+    toolbox::logger::StepMark::info("==== [HEAD] FAIL:403 no permission dir ====");
+    http::runHead("./test_dir/no_permission_dir/", "", true, response);
 }
 
 void head_test() {

--- a/test/http/response/method/main.cpp
+++ b/test/http/response/method/main.cpp
@@ -3,8 +3,8 @@ void head_test();
 void post_test();
 
 int main() {
-    get_test();
-    head_test();
+    // get_test();
+    // head_test();
     post_test();
     return 0;
 }

--- a/test/http/response/method/main.cpp
+++ b/test/http/response/method/main.cpp
@@ -3,8 +3,8 @@ void head_test();
 void post_test();
 
 int main() {
-    // get_test();
-    // head_test();
+    get_test();
+    head_test();
     post_test();
     return 0;
 }

--- a/test/http/response/method/main.cpp
+++ b/test/http/response/method/main.cpp
@@ -1,8 +1,10 @@
 void get_test();
 void head_test();
+void post_test();
 
 int main() {
     get_test();
     head_test();
+    post_test();
     return 0;
 }

--- a/test/http/response/method/post.cpp
+++ b/test/http/response/method/post.cpp
@@ -1,0 +1,246 @@
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <cstdio>
+#include <fstream>
+#include <map>
+
+#include "../../../../src/http/http_status.hpp"
+#include "../../../../src/http/case_insensitive_less.hpp"
+#include "../../../../src/http/request/http_fields.hpp"
+#include "../../../../src/http/response/method_utils.hpp"
+#include "../../../../src/http/response/post_method.hpp"
+#include "../../../../src/http/response/response.hpp"
+#include "../../../../src/http/http_namespace.hpp"
+
+static void setupTestEnvironment() {
+    mkdir("./uploads", 0755);
+    mkdir("./uploads/no_permission_dir", 0000);
+}
+
+static void cleanupTestEnvironment() {
+    // chmod("./test_dir/no_permission_dir", 0755);
+    // rmdir("./test_dir/no_permission_dir");
+    // rmdir("./test_dir");
+}
+
+void test_urlencoded() {
+    http::HTTPFields fields;
+    http::Response response;
+
+    // 成功ケース: application/x-www-form-urlencoded形式の正常なリクエスト
+    toolbox::logger::StepMark::info("==== POST test_urlencoded: success case ====");
+    std::string successBody = "name=test_user&age=25&comment=Hello%20World";
+    std::ostringstream lengthStr1;
+    lengthStr1 << successBody.length();
+    
+    fields.get()["Content-Length"].push_back(lengthStr1.str());
+    fields.get()["Content-Type"].push_back("application/x-www-form-urlencoded");
+    http::runPost("./uploads", successBody, fields, response);
+}
+
+void test_urlencoded_failure() {
+    http::HTTPFields fields;
+    http::Response response;
+
+    // 失敗ケース: invalid percent-encoding
+    toolbox::logger::StepMark::info("==== POST test_urlencoded_failure: failure case ====");
+    std::string failureBody = "name=fail_user%1operation=write_to_forbidden";
+    std::ostringstream lengthStr2;
+    lengthStr2 << failureBody.length();
+    
+    fields.get()["Content-Length"].push_back(lengthStr2.str());
+    fields.get()["Content-Type"].push_back("application/x-www-form-urlencoded");
+    http::runPost("./uploads", failureBody, fields, response);
+}
+
+void test_multipart_form_data() {
+    http::HTTPFields fields;
+    http::Response response;
+
+    toolbox::logger::StepMark::info("==== POST multipart/form-data: success case ====");
+    std::string successBody = "--boundary\r\n"
+                              "Content-Disposition: form-data; name=\"field1\"; filename=\"example1.txt\"\r\n"
+                              "\r\n"
+                              "value1\r\n"
+                              "--boundary\r\n"
+                              "Content-Disposition: form-data; name=\"field2\"; filename=\"example2.txt\"\r\n"
+                              "\r\n"
+                              "value2\r\n"
+                              "--boundary\r\n"
+                              "Content-Disposition: form-data; name=\"field1\"; filename=\"example1.txt\"\r\n"
+                              "\r\n"
+                              "value1\r\n"
+                              "--boundary--";
+    std::ostringstream lengthStr3;
+    lengthStr3 << successBody.length();
+    
+    fields.get()["Content-Length"].push_back(lengthStr3.str());
+    fields.get()["Content-Type"].push_back("multipart/form-data; boundary=boundary");
+    http::runPost("./uploads", successBody, fields, response);
+}
+
+void test_multipart_form_data_failure() {
+    http::HTTPFields fields;
+    http::Response response;
+
+    toolbox::logger::StepMark::info("==== POST multipart/form-data: failure case ====");
+    std::string failureBody = "--boundary\r\n"
+                              "Content-Disposition: form-data; name=\"field1\"\r\n"
+                              "\r\n"
+                              "value1\r\n"
+                              "--boundary--";
+    std::ostringstream lengthStr4;
+    lengthStr4 << failureBody.length();
+    fields.get()["Content-Length"].push_back(lengthStr4.str());
+    fields.get()["Content-Type"].push_back("multipart/form-data; boundary=boundary");
+    http::runPost("./uploads", failureBody, fields, response);
+}
+
+void test_normal_post() {
+    http::HTTPFields fields;
+    http::Response response;
+
+    toolbox::logger::StepMark::info("==== POST test_normal_post: success case ====");
+    std::string successBody = "This is a test content for normal POST request";
+    std::ostringstream lengthStr;
+    lengthStr << successBody.length();
+    
+    fields.get()["Content-Length"].push_back(lengthStr.str());
+    http::runPost("./uploads", successBody, fields, response);
+}
+
+void test_image_upload() {
+    http::HTTPFields fields;
+    http::Response response;
+
+    toolbox::logger::StepMark::info("==== POST test_image_upload: success case ====");
+    
+    // 1x1 ピクセルのPNG画像のバイナリデータ
+    const unsigned char png_data[] = {
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+        0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
+        0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+        0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
+    };
+    
+    std::string imageBody(reinterpret_cast<const char*>(png_data), sizeof(png_data));
+    std::ostringstream lengthStr;
+    lengthStr << imageBody.length();
+
+    fields.get()["Content-Length"].push_back(lengthStr.str());
+    fields.get()["Content-Type"].push_back("image/png");
+    http::runPost("./uploads", imageBody, fields, response);
+}
+
+void test_multipart_image_upload() {
+    http::HTTPFields fields;
+    http::Response response;
+
+    toolbox::logger::StepMark::info("==== POST test_multipart_image_upload: success case ====");
+    
+    // const unsigned char png_data[] = {
+    //     0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+    //     0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    //     0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
+    //     0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+    //     0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+    //     0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
+    // };
+
+    const unsigned char png_data[] = {
+    // PNG署名 (8バイト)
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+    
+    // IHDRチャンク
+    0x00, 0x00, 0x00, 0x0D,  // チャンク長: 13バイト
+    0x49, 0x48, 0x44, 0x52,  // "IHDR"
+    0x00, 0x00, 0x00, 0x0A,  // 幅: 10ピクセル (変更点)
+    0x00, 0x00, 0x00, 0x0A,  // 高さ: 10ピクセル (変更点)
+    0x08, 0x06, 0x00, 0x00, 0x00,  // ビット深度, カラータイプ, その他フラグ
+    0x3A, 0x98, 0x2F, 0x0A,  // IHDRのCRC (幅・高さ変更に伴い更新)
+    
+    // IDATチャンク
+    0x00, 0x00, 0x00, 0x2C,  // チャンク長: 44バイト (10×10用に増加)
+    0x49, 0x44, 0x41, 0x54,  // "IDAT"
+    // 10×10ピクセル用の圧縮データ (44バイト)
+    0x78, 0x9C, 0x63, 0x60, 0x60, 0x60, 0xF0, 0xFF, 0xFF, 0xFF, 0x3F, 0x03,
+    0x03, 0x03, 0xC3, 0x7F, 0x06, 0x30, 0x60, 0x80, 0xD2, 0x0C, 0x0C, 0x70,
+    0x1A, 0x01, 0x30, 0x20, 0x68, 0x06, 0x28, 0x0D, 0xC6, 0x20, 0x1A, 0x43,
+    0x0C, 0x1D, 0x60, 0x68, 0x60, 0x60, 0x00, 0x00, 0x76, 0x21, 0x6D, 0x24,
+    
+    // CRC for IDAT
+    0x0E, 0x7C, 0x75, 0x31,
+    
+    // IENDチャンク (変更なし)
+    0x00, 0x00, 0x00, 0x00,  // チャンク長: 0バイト
+    0x49, 0x45, 0x4E, 0x44,  // "IEND"
+    0xAE, 0x42, 0x60, 0x82   // IENDのCRC
+};
+    
+    std::string imageData(reinterpret_cast<const char*>(png_data), sizeof(png_data));
+    
+    std::string boundary = "boundary123";
+    std::string header = "--" + boundary + "\r\n"
+                       "Content-Disposition: form-data; name=\"image\"; filename=\"test.png\"\r\n"
+                       "Content-Type: image/png\r\n"
+                       "\r\n";
+    
+    std::string descHeader = "\r\n--" + boundary + "\r\n"
+                           "Content-Disposition: form-data; name=\"description\"; filename=\"test.txt\"\r\n"
+                           "\r\n";
+    
+    std::string descBody = "This is a test image upload";
+    
+    std::string endBoundary = "\r\n--" + boundary + "--";
+    
+    std::string successBody = header + imageData + descHeader + descBody + endBoundary;
+    
+    std::ostringstream lengthStr;
+    lengthStr << successBody.length();
+    
+    fields.get()["Content-Length"].push_back(lengthStr.str());
+    fields.get()["Content-Type"].push_back("multipart/form-data; boundary=" + boundary);
+    http::runPost("./uploads", successBody, fields, response);
+}
+
+static void runTests() {
+    test_normal_post();
+    sleep(1);
+
+    // test_image_upload();  // 拡張子を確認する必要がある
+    // sleep(1);
+
+    test_multipart_image_upload();
+    sleep(1);
+
+    test_urlencoded();
+    sleep(1);
+
+    test_urlencoded_failure();
+    sleep(1);
+
+    test_multipart_form_data();
+    sleep(1);
+
+    test_multipart_form_data_failure();
+    sleep(1);
+}
+
+void post_test() {
+    try {
+        setupTestEnvironment();
+        runTests();
+        cleanupTestEnvironment();
+        std::cout << "OK" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << "FAILED" << e.what() << std::endl;
+        cleanupTestEnvironment();
+    }
+}

--- a/test/http/response/method/post.cpp
+++ b/test/http/response/method/post.cpp
@@ -1,6 +1,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <dirent.h>
 
 #include <cassert>
 #include <iostream>
@@ -17,27 +18,57 @@
 #include "../../../../src/http/response/response.hpp"
 #include "../../../../src/http/http_namespace.hpp"
 
-static void setupTestEnvironment() {
+void setupTestEnvironment() {
     mkdir("./uploads", 0755);
     mkdir("./uploads/no_permission_dir", 0000);
 }
 
-static void cleanupTestEnvironment() {
-    // chmod("./test_dir/no_permission_dir", 0755);
-    // rmdir("./test_dir/no_permission_dir");
-    // rmdir("./test_dir");
+void testSimplePost() {
+    toolbox::logger::StepMark::info("==== POST testSimplePost: success case ====");
+
+    http::HTTPFields fields;
+    http::Response response;
+
+    std::string content = "normal post test";
+    fields.get()["Content-Length"].push_back(toolbox::to_string(content.length()));
+    http::runPost("./uploads", content, fields, response);
+}
+
+void test_normal_post() {
+    http::HTTPFields fields;
+    http::Response response;
+
+    toolbox::logger::StepMark::info("==== POST test_normal_post: success case ====");
+    std::string successBody = "This is a test content for normal POST request";
+    std::ostringstream lengthStr;
+    lengthStr << successBody.length();
+
+    fields.get()["Content-Length"].push_back(lengthStr.str());
+    http::runPost("./uploads", successBody, fields, response);
+}
+
+void testUrlEncodedForm() {
+    toolbox::logger::StepMark::info("==== POST testUrlEncodedForm: success case ====");
+
+    http::HTTPFields fields;
+    http::Response response;
+    std::string formData = "name=test_user&message=Hello%20World&age=25";
+
+    fields.get()["Content-Type"].push_back("application/x-www-form-urlencoded");
+    fields.get()["Content-Length"].push_back(toolbox::to_string(formData.length()));
+
+    http::runPost("./uploads", formData, fields, response);
 }
 
 void test_urlencoded() {
     http::HTTPFields fields;
     http::Response response;
 
-    // 成功ケース: application/x-www-form-urlencoded形式の正常なリクエスト
     toolbox::logger::StepMark::info("==== POST test_urlencoded: success case ====");
     std::string successBody = "name=test_user&age=25&comment=Hello%20World";
     std::ostringstream lengthStr1;
     lengthStr1 << successBody.length();
-    
+
     fields.get()["Content-Length"].push_back(lengthStr1.str());
     fields.get()["Content-Type"].push_back("application/x-www-form-urlencoded");
     http::runPost("./uploads", successBody, fields, response);
@@ -47,15 +78,37 @@ void test_urlencoded_failure() {
     http::HTTPFields fields;
     http::Response response;
 
-    // 失敗ケース: invalid percent-encoding
     toolbox::logger::StepMark::info("==== POST test_urlencoded_failure: failure case ====");
     std::string failureBody = "name=fail_user%1operation=write_to_forbidden";
     std::ostringstream lengthStr2;
     lengthStr2 << failureBody.length();
-    
+
     fields.get()["Content-Length"].push_back(lengthStr2.str());
     fields.get()["Content-Type"].push_back("application/x-www-form-urlencoded");
     http::runPost("./uploads", failureBody, fields, response);
+}
+
+void testMultipartFormData() {
+    toolbox::logger::StepMark::info("==== POST testMultipartFormData: success case ====");
+
+    http::HTTPFields fields;
+    http::Response response;
+
+    std::string boundary = "testboundary";
+    std::string formData = 
+        "--" + boundary + "\r\n"
+        "Content-Disposition: form-data; name=\"field1\"; filename=\"test1.txt\"\r\n"
+        "\r\n"
+        "これはテキストファイルの内容です\r\n"
+        "--" + boundary + "\r\n"
+        "Content-Disposition: form-data; name=\"field2\"; filename=\"test2.txt\"\r\n"
+        "\r\n"
+        "これは2つ目のファイルの内容です\r\n"
+        "--" + boundary + "--";
+
+    fields.get()["Content-Type"].push_back("multipart/form-data; boundary=" + boundary);
+    fields.get()["Content-Length"].push_back(toolbox::to_string(formData.length()));
+    http::runPost("./uploads", formData, fields, response);
 }
 
 void test_multipart_form_data() {
@@ -78,7 +131,7 @@ void test_multipart_form_data() {
                               "--boundary--";
     std::ostringstream lengthStr3;
     lengthStr3 << successBody.length();
-    
+
     fields.get()["Content-Length"].push_back(lengthStr3.str());
     fields.get()["Content-Type"].push_back("multipart/form-data; boundary=boundary");
     http::runPost("./uploads", successBody, fields, response);
@@ -88,7 +141,7 @@ void test_multipart_form_data_failure() {
     http::HTTPFields fields;
     http::Response response;
 
-    toolbox::logger::StepMark::info("==== POST multipart/form-data: failure case ====");
+    toolbox::logger::StepMark::info("==== POST multipart/form-data: success case ====");
     std::string failureBody = "--boundary\r\n"
                               "Content-Disposition: form-data; name=\"field1\"\r\n"
                               "\r\n"
@@ -101,26 +154,12 @@ void test_multipart_form_data_failure() {
     http::runPost("./uploads", failureBody, fields, response);
 }
 
-void test_normal_post() {
-    http::HTTPFields fields;
-    http::Response response;
-
-    toolbox::logger::StepMark::info("==== POST test_normal_post: success case ====");
-    std::string successBody = "This is a test content for normal POST request";
-    std::ostringstream lengthStr;
-    lengthStr << successBody.length();
-    
-    fields.get()["Content-Length"].push_back(lengthStr.str());
-    http::runPost("./uploads", successBody, fields, response);
-}
-
 void test_image_upload() {
     http::HTTPFields fields;
     http::Response response;
 
     toolbox::logger::StepMark::info("==== POST test_image_upload: success case ====");
-    
-    // 1x1 ピクセルのPNG画像のバイナリデータ
+
     const unsigned char png_data[] = {
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
         0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
@@ -129,7 +168,7 @@ void test_image_upload() {
         0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
         0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
     };
-    
+
     std::string imageBody(reinterpret_cast<const char*>(png_data), sizeof(png_data));
     std::ostringstream lengthStr;
     lengthStr << imageBody.length();
@@ -144,103 +183,74 @@ void test_multipart_image_upload() {
     http::Response response;
 
     toolbox::logger::StepMark::info("==== POST test_multipart_image_upload: success case ====");
-    
-    // const unsigned char png_data[] = {
-    //     0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
-    //     0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
-    //     0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
-    //     0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
-    //     0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
-    //     0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
-    // };
 
     const unsigned char png_data[] = {
-    // PNG署名 (8バイト)
-    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-    
-    // IHDRチャンク
-    0x00, 0x00, 0x00, 0x0D,  // チャンク長: 13バイト
-    0x49, 0x48, 0x44, 0x52,  // "IHDR"
-    0x00, 0x00, 0x00, 0x0A,  // 幅: 10ピクセル (変更点)
-    0x00, 0x00, 0x00, 0x0A,  // 高さ: 10ピクセル (変更点)
-    0x08, 0x06, 0x00, 0x00, 0x00,  // ビット深度, カラータイプ, その他フラグ
-    0x3A, 0x98, 0x2F, 0x0A,  // IHDRのCRC (幅・高さ変更に伴い更新)
-    
-    // IDATチャンク
-    0x00, 0x00, 0x00, 0x2C,  // チャンク長: 44バイト (10×10用に増加)
-    0x49, 0x44, 0x41, 0x54,  // "IDAT"
-    // 10×10ピクセル用の圧縮データ (44バイト)
-    0x78, 0x9C, 0x63, 0x60, 0x60, 0x60, 0xF0, 0xFF, 0xFF, 0xFF, 0x3F, 0x03,
-    0x03, 0x03, 0xC3, 0x7F, 0x06, 0x30, 0x60, 0x80, 0xD2, 0x0C, 0x0C, 0x70,
-    0x1A, 0x01, 0x30, 0x20, 0x68, 0x06, 0x28, 0x0D, 0xC6, 0x20, 0x1A, 0x43,
-    0x0C, 0x1D, 0x60, 0x68, 0x60, 0x60, 0x00, 0x00, 0x76, 0x21, 0x6D, 0x24,
-    
-    // CRC for IDAT
-    0x0E, 0x7C, 0x75, 0x31,
-    
-    // IENDチャンク (変更なし)
-    0x00, 0x00, 0x00, 0x00,  // チャンク長: 0バイト
-    0x49, 0x45, 0x4E, 0x44,  // "IEND"
-    0xAE, 0x42, 0x60, 0x82   // IENDのCRC
-};
-    
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+        0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
+        0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+        0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
+    };
+
     std::string imageData(reinterpret_cast<const char*>(png_data), sizeof(png_data));
-    
+
     std::string boundary = "boundary123";
     std::string header = "--" + boundary + "\r\n"
                        "Content-Disposition: form-data; name=\"image\"; filename=\"test.png\"\r\n"
                        "Content-Type: image/png\r\n"
                        "\r\n";
-    
+
     std::string descHeader = "\r\n--" + boundary + "\r\n"
                            "Content-Disposition: form-data; name=\"description\"; filename=\"test.txt\"\r\n"
                            "\r\n";
-    
+
     std::string descBody = "This is a test image upload";
-    
     std::string endBoundary = "\r\n--" + boundary + "--";
-    
     std::string successBody = header + imageData + descHeader + descBody + endBoundary;
-    
+
     std::ostringstream lengthStr;
     lengthStr << successBody.length();
-    
+
     fields.get()["Content-Length"].push_back(lengthStr.str());
     fields.get()["Content-Type"].push_back("multipart/form-data; boundary=" + boundary);
     http::runPost("./uploads", successBody, fields, response);
 }
 
+void testErrorCase() {
+    toolbox::logger::StepMark::info("==== POST testErrorCase: failure case ====");
+    http::HTTPFields fields;
+    http::Response response;
+
+    std::string content = "no permission directory";
+    fields.get()["Content-Length"].push_back(toolbox::to_string(content.length()));
+    http::runPost("./uploads/no_permission", content, fields, response);
+}
+
 static void runTests() {
+    testSimplePost();
     test_normal_post();
-    sleep(1);
 
-    // test_image_upload();  // 拡張子を確認する必要がある
-    // sleep(1);
-
-    test_multipart_image_upload();
-    sleep(1);
-
+    testUrlEncodedForm();
     test_urlencoded();
-    sleep(1);
-
     test_urlencoded_failure();
-    sleep(1);
 
+    testMultipartFormData();
     test_multipart_form_data();
-    sleep(1);
-
     test_multipart_form_data_failure();
-    sleep(1);
+
+    test_image_upload();
+    test_multipart_image_upload();
+
+    testErrorCase();
 }
 
 void post_test() {
     try {
         setupTestEnvironment();
         runTests();
-        cleanupTestEnvironment();
         std::cout << "OK" << std::endl;
     } catch (const std::exception& e) {
         std::cerr << "FAILED" << e.what() << std::endl;
-        cleanupTestEnvironment();
     }
 }

--- a/test/http/response/method/post.cpp
+++ b/test/http/response/method/post.cpp
@@ -24,7 +24,7 @@ void setupTestEnvironment() {
 }
 
 void testSimplePost() {
-    toolbox::logger::StepMark::info("==== POST testSimplePost: success case ====");
+    toolbox::logger::StepMark::info("==== [POST] SUCCESS:201 simple post: success case ====");
 
     http::HTTPFields fields;
     http::Response response;
@@ -38,7 +38,7 @@ void test_normal_post() {
     http::HTTPFields fields;
     http::Response response;
 
-    toolbox::logger::StepMark::info("==== POST test_normal_post: success case ====");
+    toolbox::logger::StepMark::info("==== [POST] SUCCESS:201 normal post: success case ====");
     std::string successBody = "This is a test content for normal POST request";
     std::ostringstream lengthStr;
     lengthStr << successBody.length();
@@ -48,7 +48,7 @@ void test_normal_post() {
 }
 
 void testUrlEncodedForm() {
-    toolbox::logger::StepMark::info("==== POST testUrlEncodedForm: success case ====");
+    toolbox::logger::StepMark::info("==== [POST] SUCCESS:201 urlencoded: success case ====");
 
     http::HTTPFields fields;
     http::Response response;
@@ -64,7 +64,7 @@ void test_urlencoded() {
     http::HTTPFields fields;
     http::Response response;
 
-    toolbox::logger::StepMark::info("==== POST test_urlencoded: success case ====");
+    toolbox::logger::StepMark::info("==== [POST] SUCCESS:201 urlencoded: success case ====");
     std::string successBody = "name=test_user&age=25&comment=Hello%20World";
     std::ostringstream lengthStr1;
     lengthStr1 << successBody.length();
@@ -78,7 +78,7 @@ void test_urlencoded_failure() {
     http::HTTPFields fields;
     http::Response response;
 
-    toolbox::logger::StepMark::info("==== POST test_urlencoded_failure: failure case ====");
+    toolbox::logger::StepMark::info("==== [POST] FAIL:400 urlencoded failure case ====");
     std::string failureBody = "name=fail_user%1operation=write_to_forbidden";
     std::ostringstream lengthStr2;
     lengthStr2 << failureBody.length();
@@ -89,7 +89,7 @@ void test_urlencoded_failure() {
 }
 
 void testMultipartFormData() {
-    toolbox::logger::StepMark::info("==== POST testMultipartFormData: success case ====");
+    toolbox::logger::StepMark::info("==== [POST] SUCCESS:201 multipart/form-data: success case ====");
 
     http::HTTPFields fields;
     http::Response response;
@@ -115,7 +115,7 @@ void test_multipart_form_data() {
     http::HTTPFields fields;
     http::Response response;
 
-    toolbox::logger::StepMark::info("==== POST multipart/form-data: success case ====");
+    toolbox::logger::StepMark::info("==== [POST] SUCCESS:201 multipart/form-data: success case ====");
     std::string successBody = "--boundary\r\n"
                               "Content-Disposition: form-data; name=\"field1\"; filename=\"example1.txt\"\r\n"
                               "\r\n"
@@ -141,7 +141,7 @@ void test_multipart_form_data_failure() {
     http::HTTPFields fields;
     http::Response response;
 
-    toolbox::logger::StepMark::info("==== POST multipart/form-data: success case ====");
+    toolbox::logger::StepMark::info("==== [POST] SUCCESS:201 multipart/form-data: success case ====");
     std::string failureBody = "--boundary\r\n"
                               "Content-Disposition: form-data; name=\"field1\"\r\n"
                               "\r\n"
@@ -158,7 +158,7 @@ void test_image_upload() {
     http::HTTPFields fields;
     http::Response response;
 
-    toolbox::logger::StepMark::info("==== POST test_image_upload: success case ====");
+    toolbox::logger::StepMark::info("==== [POST] SUCCESS:201 image upload ====");
 
     const unsigned char png_data[] = {
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
@@ -182,7 +182,7 @@ void test_multipart_image_upload() {
     http::HTTPFields fields;
     http::Response response;
 
-    toolbox::logger::StepMark::info("==== POST test_multipart_image_upload: success case ====");
+    toolbox::logger::StepMark::info("==== [POST] SUCCESS:201 multipart/form-data image upload ====");
 
     const unsigned char png_data[] = {
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
@@ -218,7 +218,7 @@ void test_multipart_image_upload() {
 }
 
 void testErrorCase() {
-    toolbox::logger::StepMark::info("==== POST testErrorCase: failure case ====");
+    toolbox::logger::StepMark::info("==== [POST] FAIL:500 no permission directory ====");
     http::HTTPFields fields;
     http::Response response;
 


### PR DESCRIPTION
## 概要
postメソッド + ContentTypeManager作成によ変更 + テスト形式変更
## 変更内容

* PostMethodの作成
　- ファイル名はPOSTされた時間を表す。
　- 被りがあった場合は(1)のように数値が補助的に付く
　- MultipartFormData bodyに区切りが存在し内部でfilenameの指定ができるため指定された場合はそのfilenameを使用する。指定がなかった場合は、作成するファイルが無いとみなし作成しない。
　- UrlEncoded
* ContentTypeManagerの作成
    - レスポンスを作る際に色々なところから使用したくなるのと、内容は変わることがないのでシングルトンを意識して作成してみた
* テスト
　- テストの結果をstepmark.logに集約しました。

主な変更は
post_method.c/hpp
post.cpp
content_type_manager.c/hpp


## 関連Issue

## 影響範囲

* src/http/response
* test/http/response/method

## テスト

* test/http/response/method make ステータス値がstepmark.logに記録されます

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | `ContentTypeManager`クラスが追加され、ファイル拡張子からコンテンツタイプを取得する機能が実装されました。 |
| Refactor | エラーハンドリングが例外ベースに変更され、コードの流れが改善されました。 |
| Test | POSTメソッドとコンテンツタイプ管理のテストが追加されました。 |
| Chore | `.gitignore`に`uploads`ディレクトリが追加されました。 |

このプルリクエストでは、シングルトンパターンを用いた`ContentTypeManager`の導入や、例外処理への移行によるエラーハンドリングの改善が素晴らしいです。これにより、コードの保守性と拡張性が向上しています。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->