### PR TITLE
84 avoid throwing exception

### DIFF
--- a/test/toolbox/stepmark/Makefile
+++ b/test/toolbox/stepmark/Makefile
@@ -1,4 +1,4 @@
-NAME = accesslog_test.out
+NAME = stepmark_test.out
 
 SRCS = main.cpp ../../../toolbox/stepmark.cpp
 OBJS = $(SRCS:.cpp=.o)

--- a/test/toolbox/stepmark/Makefile
+++ b/test/toolbox/stepmark/Makefile
@@ -1,0 +1,25 @@
+NAME = accesslog_test.out
+
+SRCS = main.cpp ../../../toolbox/stepmark.cpp
+OBJS = $(SRCS:.cpp=.o)
+
+CXX = c++
+CXXFLAGS = -Wall -Wextra -Werror -std=c++98
+
+run: $(NAME)
+	./$(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJS)
+
+clean:
+	rm -f $(OBJS) $(NAME)
+
+fclean: clean
+	rm -f $(NAME)
+
+re: fclean all
+
+all: $(NAME)
+
+.PHONY: all clean fclean re run

--- a/test/toolbox/stepmark/main.cpp
+++ b/test/toolbox/stepmark/main.cpp
@@ -1,0 +1,17 @@
+
+#include "../../../toolbox/stepmark.hpp"
+
+int main() {
+    toolbox::logger::StepMark::setLevel(toolbox::logger::DEBUG);
+    toolbox::logger::StepMark::setLogFile("stepmark.log");
+
+    toolbox::logger::StepMark::debug("This is a debug message.");
+    toolbox::logger::StepMark::info("This is an info message.");
+    toolbox::logger::StepMark::warning("This is a warning message.");
+    toolbox::logger::StepMark::error("This is an error message.");
+    toolbox::logger::StepMark::critical("This is a critical message.");
+
+    toolbox::logger::StepMark::setLogFile("no_permission");
+
+    return 0;
+}

--- a/test/toolbox/stepmark/main.cpp
+++ b/test/toolbox/stepmark/main.cpp
@@ -11,7 +11,7 @@ int main() {
     toolbox::logger::StepMark::error("This is an error message.");
     toolbox::logger::StepMark::critical("This is a critical message.");
 
-    toolbox::logger::StepMark::setLogFile("no_permission");
+    toolbox::logger::StepMark::setLogFile("no_permission_to_write");
 
     return 0;
 }

--- a/toolbox/access.cpp
+++ b/toolbox/access.cpp
@@ -1,5 +1,16 @@
 // Copyright 2025 Ideal Broccoli
 
+/*
+AccessLog class does not throw exceptions
+because the log is not critical to the program's execution and
+throwing exceptions would require additional error handling
+which is not needed in this case.
+The class is designed to be simple and lightweight,
+allowing for easy logging without the overhead of exception handling.
+The class uses a singleton pattern to ensure that only one instance of the logger exists.
+The class is not thread-safe, so it should not be used in a multi-threaded environment.
+*/
+
 #include "access.hpp"
 
 #include <iostream>

--- a/toolbox/stepmark.hpp
+++ b/toolbox/stepmark.hpp
@@ -35,6 +35,7 @@ class StepMark {
     std::ofstream _logFile;
 
     static StepMark& getInstance();
+    void openLogFile();
 
     StepMark();
     ~StepMark();


### PR DESCRIPTION
## 概要

StepMarkクラスが例外を投げないように変更した

## 変更内容

* StepMarkクラスはあくまでログのクラスであり、必ずしも必要な機能ではない
* このようなクラスが例外を投げる可能性があると、それに対応する必要があり不便
* また、ログクラスの例外によって、プログラム全体の動きが止められるべきではない
* そのため、ファイルを開けないなどの問題が生じた場合は、デフォルトのログファイルパスを使うか、ログを取らないなどの対応するかといった例外の生じない方法で処理するように変更した

## 関連Issue

* #84 

## 影響範囲

* StepMarkクラス

## テスト

* test/toolbox/stepmarkディレクトリで`make`

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | `accesslog_test.out`および`stepmark_test.out`をビルド・実行するMakefileが追加されました。 |
| Refactor | `StepMark`クラスと`AccessLog`クラスが例外を投げない設計に変更され、ログファイルのオープン処理が改善されました。 |
| Test | `toolbox::logger::StepMark`クラスのログレベルとログファイル設定をテストするコードが追加されました。 |

このプルリクエストは、例外処理を改善し、ログ機能がプログラムの安定性に影響を与えないようにするための重要な変更を含んでいます。特に、例外を投げずにエラーメッセージを標準エラー出力に表示することで、ユーザー体験が向上しています。また、Makefileの追加により、テストの自動化が容易になり、開発効率が向上しました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->