### PR TITLE
102 clientクラスにclient addrを追加する

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
                                 throw std::runtime_error("accept failed");
                             }
                             std::cout << server->getName() << " accepted client fd: " << client_sock << std::endl;
-                            toolbox::SharedPtr<Client> client(new Client(client_sock));
+                            toolbox::SharedPtr<Client> client(new Client(client_sock, client_addr, addr_len));
                             epoll.addClient(client_sock, client); // this func will throw exception
                         } catch(std::exception& e) {
                             std::cerr << e.what() << std:: endl;

--- a/src/socket/client.cpp
+++ b/src/socket/client.cpp
@@ -46,7 +46,7 @@ int Client::getFd() const {
 }
 
 std::string Client::getIp() const {
-    uint32_t ip = _client_addr.sin_addr.s_addr;
+    uint32_t ip = ntohl(_client_addr.sin_addr.s_addr);
     std::string ip_str = toolbox::to_string((ip >> 24) & 0xFF) + "." +
         toolbox::to_string((ip >> 16) & 0xFF) + "." +
         toolbox::to_string((ip >> 8) & 0xFF) + "." +

--- a/src/socket/client.cpp
+++ b/src/socket/client.cpp
@@ -5,11 +5,17 @@
 #include <sys/socket.h>
 #include <unistd.h>
 #include <iostream>
+#include <string>
+
+#include "../../toolbox/string.hpp"
 
 Client::Client() : _socket_fd(-1) {
 }
 
-Client::Client(int fd): _socket_fd(fd) {
+Client::Client(int fd, const struct sockaddr_in& client_addr,
+            socklen_t client_addr_len) :
+            _socket_fd(fd), _client_addr(client_addr),
+            _client_addr_len(client_addr_len) {
 }
 
 Client::Client(const Client& other): _socket_fd(other._socket_fd) {
@@ -37,4 +43,13 @@ const char* Client::ClientException::what() const throw() {
 
 int Client::getFd() const {
     return _socket_fd;
+}
+
+std::string Client::getIp() const {
+    uint32_t ip = _client_addr.sin_addr.s_addr;
+    std::string ip_str = toolbox::to_string((ip >> 24) & 0xFF) + "." +
+        toolbox::to_string((ip >> 16) & 0xFF) + "." +
+        toolbox::to_string((ip >> 8) & 0xFF) + "." +
+        toolbox::to_string(ip & 0xFF);
+    return ip_str;
 }

--- a/src/socket/client.cpp
+++ b/src/socket/client.cpp
@@ -18,12 +18,16 @@ Client::Client(int fd, const struct sockaddr_in& client_addr,
             _client_addr_len(client_addr_len) {
 }
 
-Client::Client(const Client& other): _socket_fd(other._socket_fd) {
+Client::Client(const Client& other): _socket_fd(other._socket_fd),
+    _client_addr(other._client_addr),
+    _client_addr_len(other._client_addr_len) {
 }
 
 Client& Client::operator=(const Client& other) {
     if (this != &other) {
         _socket_fd = other._socket_fd;
+        _client_addr = other._client_addr;
+        _client_addr_len = other._client_addr_len;
     }
     return *this;
 }

--- a/src/socket/client.hpp
+++ b/src/socket/client.hpp
@@ -2,7 +2,10 @@
 
 #pragma once
 
+#include <netinet/in.h>
+
 #include <exception>
+#include <string>
 
 class Client {
  public:
@@ -13,12 +16,17 @@ class Client {
      private:
         const char* _message;
     };
-    Client();
-    explicit Client(int fd);
+    Client(int fd, const struct sockaddr_in& client_addr,
+        socklen_t client_addr_len);
     Client(const Client& other);
     Client& operator=(const Client& other);
     virtual ~Client();
     int getFd() const;
+    std::string getIp() const;
  private:
+    Client();
+
     int _socket_fd;
+    struct sockaddr_in _client_addr;
+    socklen_t _client_addr_len;
 };

--- a/test/core/client/Makefile
+++ b/test/core/client/Makefile
@@ -1,0 +1,29 @@
+NAME = client_test.out
+
+SRCS = main.cpp \
+		../../../src/socket/server.cpp \
+		../../../src/socket/client.cpp \
+		../../../src/event/epoll.cpp \
+		../../../toolbox/string.cpp 
+OBJS = $(SRCS:.cpp=.o)
+
+CXX = c++
+CXXFLAGS = -Wall -Wextra -Werror -std=c++98
+
+run: $(NAME)
+	./$(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJS)
+
+clean:
+	rm -f $(OBJS) $(NAME)
+
+fclean: clean
+	rm -f $(NAME)
+
+re: fclean all
+
+all: $(NAME)
+
+.PHONY: all clean fclean re run

--- a/test/core/client/main.cpp
+++ b/test/core/client/main.cpp
@@ -1,3 +1,5 @@
+// this is a simple version of src/core/main.cpp
+
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <fcntl.h>
@@ -23,7 +25,7 @@ int main(void) {
         server1->setName("server1");
         epoll.addServer(server1->getFd(), server1);
 
-        int cnt = 0;  // for debug
+        int cnt = 0;
         struct epoll_event events[1000];
         while (1) {
             try {
@@ -42,12 +44,11 @@ int main(void) {
                             socklen_t addr_len = sizeof(client_addr);
                             int client_sock = accept(server->getFd(), (struct sockaddr*)&client_addr, &addr_len);
                             if (client_sock == -1) {
-                                //continue?
                                 throw std::runtime_error("accept failed");
                             }
                             std::cout << server->getName() << " accepted client fd: " << client_sock << std::endl;
                             toolbox::SharedPtr<Client> client(new Client(client_sock, client_addr, addr_len));
-                            epoll.addClient(client_sock, client); // this func will throw exception
+                            epoll.addClient(client_sock, client);
                         } catch(std::exception& e) {
                             std::cerr << e.what() << std:: endl;
                         }
@@ -81,7 +82,6 @@ int main(void) {
                             std::string response = responseHeader + toolbox::to_string(responseBody.size()) + "\r\n\r\n" + responseBody;
                             if (send(client_sock, response.c_str(), response.size(), 0) == -1) {
                                 throw std::runtime_error("send failed");
-                                // Send exit status to client
                             }
                             epoll.del(client_sock);
                         } catch (std::exception& e) {

--- a/test/core/client/main.cpp
+++ b/test/core/client/main.cpp
@@ -1,0 +1,102 @@
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <unistd.h>
+#include <string>
+#include <iostream>
+#include <cerrno>
+#include <cstdio>
+#include <sstream>
+
+#include "../../../src/socket/server.hpp"
+#include "../../../src/socket/client.hpp"
+#include "../../../src/event/epoll.hpp"
+#include "../../../src/event/tagged_epoll_event.hpp"
+#include "../../../toolbox/string.hpp"
+#include "../../../toolbox/shared.hpp"
+
+int main(void) {
+    try {
+        Epoll epoll;
+        toolbox::SharedPtr<Server> server1(new Server(3000));
+        server1->setName("server1");
+        epoll.addServer(server1->getFd(), server1);
+
+        int cnt = 0;  // for debug
+        struct epoll_event events[1000];
+        while (1) {
+            try {
+                int nfds = epoll.wait(events, 1000, -1);
+                if (nfds == -1) {
+                    throw std::runtime_error("epoll_wait failed");
+                }
+                for (int i = 0; i < nfds; i++) {
+                    taggedEventData* tagged =
+                        static_cast<taggedEventData*>(events[i].data.ptr);
+                    if (tagged->server) {
+                        try {
+                            std::cout <<"---------------   server   ---------------" <<std::endl;
+                            toolbox::SharedPtr<Server> server = tagged->server;
+                            struct sockaddr_in client_addr;
+                            socklen_t addr_len = sizeof(client_addr);
+                            int client_sock = accept(server->getFd(), (struct sockaddr*)&client_addr, &addr_len);
+                            if (client_sock == -1) {
+                                //continue?
+                                throw std::runtime_error("accept failed");
+                            }
+                            std::cout << server->getName() << " accepted client fd: " << client_sock << std::endl;
+                            toolbox::SharedPtr<Client> client(new Client(client_sock, client_addr, addr_len));
+                            epoll.addClient(client_sock, client); // this func will throw exception
+                        } catch(std::exception& e) {
+                            std::cerr << e.what() << std:: endl;
+                        }
+                    } else {
+                        try {
+                            std::cout << "--------------- client " << ++cnt << " ---------------" <<std::endl;
+                            toolbox::SharedPtr<Client> client = tagged->client;
+                            int client_sock = client->getFd();
+                            std::cout << "send response to client fd: " << client_sock << std::endl;
+                            std::cout << "client ip: " << client->getIp() << std::endl;
+
+                            char buf[1024];
+                            int len = 0;
+                            std::string whole_request;
+                            do {
+                                len = recv(client_sock, buf, sizeof(buf), 0);
+                                if (len == -1) {
+                                    if (errno == EAGAIN) { //if no recv data
+                                        break;
+                                    }
+                                    throw std::runtime_error("recv failed");
+                                } else if (len == 0) {
+                                    break;
+                                } else {
+                                    whole_request.append(buf, len);
+                                }
+                            } while (len > 0);
+
+                            const char* responseHeader = "HTTP/1.1 200 OK\r\nContent-Length: ";
+                            std::string responseBody = "<html><body>hello\n" + whole_request + "</body></html>";
+                            std::string response = responseHeader + toolbox::to_string(responseBody.size()) + "\r\n\r\n" + responseBody;
+                            if (send(client_sock, response.c_str(), response.size(), 0) == -1) {
+                                throw std::runtime_error("send failed");
+                                // Send exit status to client
+                            }
+                            epoll.del(client_sock);
+                        } catch (std::exception& e) {
+                            std::cerr << e.what() << std:: endl;
+                        }
+                    }
+                }
+            } catch (std::exception& e) {
+                std::cerr << e.what() << std::endl;
+            }
+        }
+        epoll.del(server1->getFd());
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## 概要

102 clientクラスにclient addrを追加する

## 変更内容

* Clientクラスのコンストラクタの引数に、`const struct sockaddr_in& client_addr`,`socklen_t client_addr_len`を追加する
* Clientのデフォルトコンストラクタを使うことはないため、privateにした
* IPアドレスを文字列として返すgetIPという関数をClientクラスに追加した

## 関連Issue

* #102 

## 影響範囲

* Clientクラス
* main関数
* Requestクラス(未実装)

## テスト

* test/core/clientディレクトリで`make`すると、簡易サーバーが起動します。localhostの3000番ポートにアクセスすると、クライアントのIPアドレスがサーバー側のターミナルに表示されます。
* ローカル接続では127.0.0.1がデフォルトですが、`sudo ip addr add 192.2.32.23 dev lo`などとすると、一時的にIPアドレスを追加することができるので、`curl -i 192.2.32.23:3000`によりアクセスできるようになります。この場合、サーバー側もクライアント側も192.2.32.23になることがあり、127.0.0.1以外からのアクセスもテストできるようになります

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | `Client`クラスにクライアントのIPアドレスを管理する機能が追加されました。 |
| Test | クライアント接続処理のテスト用Makefileが追加され、テスト実行ファイルをビルド可能になりました。 |

このプルリクエストでは、クライアントのIPアドレス管理機能が強化され、コードの保守性と可読性が向上しています。また、テスト環境の整備により、開発プロセスが効率的になっています。素晴らしい改善です！
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->