### PR TITLE
105 requestparserでオリジナルのrequestlineを保持する

### DIFF
--- a/src/http/request/http_request.hpp
+++ b/src/http/request/http_request.hpp
@@ -35,6 +35,7 @@ class HTTPRequest {
     ~HTTPRequest() {}
 
     HttpStatus httpStatus;
+    std::string originalRequestLine;
     std::string method;
     URI uri;
     std::string version;

--- a/src/http/request/request_parser.cpp
+++ b/src/http/request/request_parser.cpp
@@ -52,6 +52,8 @@ BaseParser::ParseStatus RequestParser::processFieldLine() {
 
         std::string line = toolbox::trim(getBuf(), symbols::CRLF);
         if (!FieldValidator::validateFieldLine(line)) {
+            toolbox::logger::StepMark::error(
+                "RequestParser: invalid character in field line");
             _request.httpStatus.set(HttpStatus::BAD_REQUEST);
             continue;
         }
@@ -85,6 +87,8 @@ BaseParser::ParseStatus RequestParser::processRequestLine() {
 void RequestParser::parseRequestLine() {
     std::string line = toolbox::trim(getBuf(), symbols::CRLF);
     if (line.find(symbols::SP) == std::string::npos) {
+        toolbox::logger::StepMark::error(
+            "RequestParser: request line has no space");
         _request.httpStatus.set(HttpStatus::BAD_REQUEST);
         return;
     }
@@ -99,7 +103,6 @@ void RequestParser::parseRequestLine() {
         _request.httpStatus.set(HttpStatus::BAD_REQUEST);
         toolbox::logger::StepMark::error(
             "RequestParser: invalid request line");
-        return;
     }
 }
 
@@ -153,10 +156,14 @@ bool RequestParser::isValidFormat() {
 void RequestParser::validateMethod() {
     if (_request.method.empty()) {
         _request.httpStatus.set(HttpStatus::BAD_REQUEST);
+        toolbox::logger::StepMark::error(
+            "RequestParser: method not found");
         return;
     }
     if (!utils::isUpperStr(_request.method)) {
         _request.httpStatus.set(HttpStatus::BAD_REQUEST);
+        toolbox::logger::StepMark::error(
+            "RequestParser: method is not uppercase");
         return;
     }
 }
@@ -301,6 +308,8 @@ void RequestParser::verifySafePath() {
     for (std::size_t i = 0; i < _request.uri.splitPath.size(); ++i) {
         if (_request.uri.splitPath[i] == "/..") {
             if (pathDeque.empty()) {
+                toolbox::logger::StepMark::error(
+                    "RequestParser: invalid path, try parent directory");
                 _request.httpStatus.set(HttpStatus::BAD_REQUEST);
                 return;
             } else {

--- a/src/http/request/request_parser.hpp
+++ b/src/http/request/request_parser.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <sstream>
 
 #include "../parsing/base_parser.hpp"
 #include "../parsing/field_validator.hpp"

--- a/test/http/request/requestline_testcase.cpp
+++ b/test/http/request/requestline_testcase.cpp
@@ -146,9 +146,9 @@ void makeMethodTests(TestVector& t) {
     r._request = " / HTTP/1.1\r\nHost: sample\r\n\r\n";
     r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
     r._isSuccessTest = false;
-    r._exceptRequest.method = "";
-    r._exceptRequest.path = "/";
-    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.method = "/";
+    r._exceptRequest.path = "HTTP/1.1";
+    r._exceptRequest.version = "";
     t.push_back(r);
     clearUri(r);
 }
@@ -590,7 +590,7 @@ void makeRequestStructureTests(TestVector& t) {
     r._isSuccessTest = false;
     r._exceptRequest.method = "GET";
     r._exceptRequest.path = "/";
-    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.version = "HTTP/1.1 extra";
     t.push_back(r);
     clearUri(r);
 }


### PR DESCRIPTION
## 概要
105 requestparserでオリジナルのrequestlineを保持する
## 変更内容

* RequestParser::parseRequestLine　trimでリクエストラインを直接操作していたが、stringstreamを経由することでオリジナルのリクエストラインが保持できるように変更した。
* エラーステータスを設定する際にlogが無く原因が分かりづらかった為、不足している部分にerror表示で追加した。

## 関連Issue

* #60 

## 影響範囲

* src/http/request

## テスト

* test/http/request makeを実行し以前のテストが同様に動くか確認
* stringstreamを使用する上で想定する値が２項目変更
エラーステータスの変更はありません。

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | HTTPリクエストのオリジナルリクエストラインを保存する機能が追加されました。 |
| Bug fix | エラーステータス設定時のログ追跡性が向上しました。 |
| Refactor | `processData`メソッドのパフォーマンスと一貫性が改善されました。 |
| Test | HTTPリクエストラインの解析に関するテストケースが更新されました。 |

このプルリクエストでは、HTTPリクエスト処理の拡張とエラーログの改善が行われ、コードの保守性とテストの信頼性が向上しています。特に、オリジナルリクエストラインの保存機能は、将来的なデバッグや解析に非常に役立つでしょう。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->