### PR TITLE
117-全体のmakefileの修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME = webserv
 
 # sources
-SRCS = $(wildcard toolbox/*.cpp) $(wildcard src/*/*.cpp)
+SRCS = $(wildcard toolbox/*.cpp) $(wildcard src/*/*.cpp) $(wildcard src/*/*/*.cpp)
 
 OBJS = $(SRCS:.cpp=.o)
 


### PR DESCRIPTION
## 概要

$(wildcard src/*/*/*.cpp)をSRCSに追加

## 変更内容

$(wildcard src/*/*/*.cpp)をSRCSに追加

## 関連Issue

* #117

## 影響範囲

* Makefile

## テスト

* 特になし

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Chore | Makefileに新たなソースファイルパス`src/*/*/*.cpp`を追加し、より深いディレクトリ階層のC++ソースファイルもビルド対象に含めるようにしました。これにより、プロジェクト内のすべての関連ソースファイルが正しくコンパイルされることが期待されます。 |

このプルリクエストでは、Makefileの改善により、プロジェクト全体のビルドプロセスがより包括的になりました。特に、深いディレクトリ構造に対応することで、開発者が安心してコードを追加できる環境が整備された点が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->