### PR TITLE
116 rename test/http/request/ to test/http/request_parse/

### DIFF
--- a/test/http/request_parse/Makefile
+++ b/test/http/request_parse/Makefile
@@ -1,0 +1,36 @@
+NAME = test.out
+
+SRC_DIRS = ../../../src
+TOOLBOX_DIR = ../../../toolbox
+
+TEST_SRCS = $(wildcard $(SRC_DIRS)/http/*.cpp)\
+			$(wildcard $(SRC_DIRS)/http/request/*.cpp)\
+			$(wildcard $(SRC_DIRS)/http/parsing/*.cpp)\
+			$(wildcard $(TOOLBOX_DIR)/*.cpp)\
+			$(wildcard *.cpp) \
+            $(wildcard http/*.cpp) \
+            $(wildcard http/request/*.cpp) \
+
+CXX = c++
+CXXFLAGS = -Wall -Wextra -Werror -std=c++98 -I..
+
+TEST_OBJS = $(TEST_SRCS:.cpp=.o)
+
+all: $(NAME)
+
+$(NAME): $(TEST_OBJS)
+	$(CXX) $(CXXFLAGS) -o $(NAME) $(TEST_OBJS)
+
+clean:
+	$(RM) $(TEST_OBJS)
+
+fclean: clean
+	$(RM) $(NAME)
+	$(RM) request_test.log
+
+re: fclean all
+
+run: all
+	./$(NAME)
+
+.PHONY: all clean fclean re run

--- a/test/http/request_parse/base_test.hpp
+++ b/test/http/request_parse/base_test.hpp
@@ -1,0 +1,25 @@
+// Copyright 2025 Ideal Broccoli
+
+#pragma once
+
+#include <string>
+
+#include "../../../src/http/request/http_fields.hpp"
+#include "../../../src/http/http_namespace.hpp"
+#include "../../../src/http/http_status.hpp"
+
+class BaseTest {
+ public:
+    BaseTest() {}
+    virtual ~BaseTest() {}
+    BaseTest(const BaseTest& other) :
+        _name(other._name),
+        _request(other._request),
+        _isSuccessTest(other._isSuccessTest),
+        _httpStatus(other._httpStatus)
+    {}
+    std::string _name;
+    std::string _request;
+    bool _isSuccessTest;
+    http::HttpStatus _httpStatus;
+};

--- a/test/http/request_parse/field_test.hpp
+++ b/test/http/request_parse/field_test.hpp
@@ -1,0 +1,21 @@
+// Copyright 2025 Ideal Broccoli
+
+#pragma once
+
+#include <string>
+
+#include "../../../src/http/request/http_fields.hpp"
+#include "../../../src/http/http_namespace.hpp"
+#include "../../../src/http/http_status.hpp"
+#include "base_test.hpp"
+
+class FieldTest : public BaseTest {
+ public:
+    FieldTest() : BaseTest() {}
+    ~FieldTest() {}
+    FieldTest(const FieldTest& other) :
+        BaseTest(other),
+        _exceptMap(other._exceptMap)
+    {}
+    http::HTTPFields::FieldMap _exceptMap;
+};

--- a/test/http/request_parse/field_testcase.cpp
+++ b/test/http/request_parse/field_testcase.cpp
@@ -1,0 +1,795 @@
+// Copyright 2025 Ideal Broccoli
+
+#include <vector>
+#include <string>
+#include <iostream>
+#include <map>
+
+#include "../../../src/http/http_status.hpp"
+#include "field_test.hpp"
+#include "../../../src/http/request/request_parser.hpp"
+
+typedef std::vector<FieldTest> TestVector;
+
+void showField(http::RequestParser& r, FieldTest& t) {
+    std::cout << "----- field -----" << std::endl;
+    std::cout << "nginx status  : " << t._httpStatus.get() << std::endl;
+    std::cout << "webserv status: " << r.get().httpStatus.get() << std::endl;
+    for (http::HTTPFields::FieldMap::iterator it = r.get().fields.get().begin();
+                it != r.get().fields.get().end(); ++it) {
+        if (!it->second.empty()) {
+            std::cout << "webserv: " << it->first << " ";
+            for (std::size_t i = 0; i < it->second.size(); ++i) {
+                std::cout << it->second[i] << ", ";
+            }
+            std::cout << std::endl;
+            http::HTTPFields::FieldMap::iterator it_t =
+                t._exceptMap.find(it->first);
+            std::cout << "nginx  : ";
+            if (it_t == t._exceptMap.end()) {
+                std::cout << "[Nginx none]" << std::endl;
+            } else {
+                std::cout << it_t->first << " ";
+                for (std::size_t i = 0; i < it_t->second.size(); ++i) {
+                    std::cout << it_t->second[i] << ", ";
+                }
+            }
+            std::cout << std::endl;
+        }
+    }
+}
+
+bool compareFields(http::RequestParser& r, FieldTest& t) {
+    if (r.get().httpStatus.get() != t._httpStatus.get()) {
+        return false;
+    }
+    for (http::HTTPFields::FieldMap::iterator it_r =
+            r.get().fields.get().begin();
+            it_r != r.get().fields.get().end(); ++it_r) {
+                http::HTTPFields::FieldMap::iterator it_t
+                    = t._exceptMap.find(it_r->first);
+        if (it_r->second.empty()) {
+            if (it_t == t._exceptMap.end()) {
+                continue;
+            }
+            return false;
+        }
+        if (it_t->second.empty() || it_r->second != it_t->second) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool runTest(FieldTest& t) {
+    toolbox::logger::StepMark::debug(t._name);
+    http::RequestParser r;
+    try {
+        r.run(t._request);
+    } catch (std::exception& e) {
+    }
+
+    if (t._isSuccessTest && compareFields(r, t)) {
+        return true;
+    } else if (t._isSuccessTest && !compareFields(r, t)) {
+        std::cout << "==== Failed: true->false " << t._name
+                  << " ====" << std::endl;
+        std::cout << t._request;
+        showField(r, t);
+        return false;
+    } else if (!t._isSuccessTest && compareFields(r, t)) {
+        return true;
+    } else {
+        std::cout << "==== Failed: false->true " << t._name
+                  << " ====" << std::endl;
+        std::cout << t._request;
+        showField(r, t);
+        return false;
+    }
+}
+
+void addFieldToMap(http::HTTPFields::FieldMap& map,
+                    const std::string& key,
+                    const std::string& value) {
+        map[key].push_back(value);
+}
+
+void makeBasicFieldTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "基本的なGETリクエスト";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);;
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "複数のヘッダーフィールド";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nAccept: text/html\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::ACCEPT, "text/html");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Hostフィールドが先頭にない";
+    f._request = "GET / HTTP/1.1\r\nAccept: text/html\r\nHost: sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::ACCEPT, "text/html");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "フィールド値が空";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nAccept:\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "ヘッダーフィールド名の大文字小文字混在";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "CoNtEnT-TyPe: text/html\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_TYPE, "text/html");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "ヘッダー値の末尾の空白";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "Accept: text/html   \r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::ACCEPT, "text/html");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeInvalidFieldTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "存在しないフィールド";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nINVALID: text/html\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "存在しないフィールドの重複";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nINVALID: text/html\r\n"
+                "INVALID: text/html\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "非常に長いフィールド名";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "X-Really-Really-Really-Really-"
+                "Really-Really-Long-Header-Name: value\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, "X-Really-Really-Really-Really-Really"
+                                "-Really-Long-Header-Name", "value");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeHostHeaderTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "Hostヘッダーが区切り文字前にスペースなし";
+    f._request = "GET / HTTP/1.1\r\nHost:sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Hostヘッダー値の前に複数スペース";
+    f._request = "GET / HTTP/1.1\r\nHost:  sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "ヘッダーフィールド値が引用符で囲まれている";
+    f._request = "GET / HTTP/1.1\r\nHost: \"sample\"\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "\"sample\"");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Hostヘッダーの後にスペース";
+    f._request = "GET / HTTP/1.1\r\nHost : sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "ホストヘッダーの前に複数のスペース";
+    f._request = "GET / HTTP/1.1\r\n  Host: sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Hostヘッダーに改行を含む";
+    f._request = "GET / HTTP/1.1\r\nHost: sam\nple\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    // addFieldToMap(f._exceptMap, http::fields::HOST, "sam");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Hostヘッダー値にスペース";
+    f._request = "GET / HTTP/1.1\r\nHost: sa mple\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "不正なホスト名（Hos）";
+    f._request = "GET / HTTP/1.1\r\nHos: sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "フィールド名なし、コロンから始まる";
+    f._request = "GET / HTTP/1.1\r\n: sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Host重複";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nHost: sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Host重複片方空";
+    f._request = "GET / HTTP/1.1\r\nHost:  \r\nHost:aa\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Hostカンマ区切り";
+    f._request = "GET / HTTP/1.1\r\nHost:aa,bb\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "aa,bb");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Hostにカンマスペースを含む値";
+    f._request = "GET / HTTP/1.1\r\nHost: sample, samplee\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Host重複（大文字小文字混在）";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nhost: sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Host重複（値が異なる）";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nHost: sam\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Hostなし";
+    f._request = "GET / HTTP/1.1\r\nAccept: text/html\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::ACCEPT, "text/html");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "ポート番号を含むHost";
+    f._request = "GET / HTTP/1.1\r\nHost: localhost:8080\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "localhost:8080");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "不正なポート番号を含むHost";
+    f._request = "GET / HTTP/1.1\r\nHost: localhost:abcd\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200
+    addFieldToMap(f._exceptMap, http::fields::HOST, "localhost:abcd");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeSpecialCharacterTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "ヘッダーフィールド値に日本語";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "X-Comment: こんにちは世界\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, "X-Comment", "こんにちは世界");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "フィールド値に特殊文字";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "X-Special: !@#$%^&*()_+\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, "X-Special", "!@#$%^&*()_+");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeDelimiterTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "ヘッダーフィールドにセミコロン使用";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nAccept; text/html\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "ヘッダー区切りが不完全";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nAccept:\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    // Acceptフィールドに値は入らない
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "フィールド名なし（コロンのみ）";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n: text/html\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "コロンなしのヘッダー";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nAccept text/html\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "ヘッダー値内に制御文字";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nAccept: sam ple\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::ACCEPT, "sam ple");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "ヘッダーフィールド名に空白";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nAcc ept: sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "ヘッダーフィールド名に特殊文字";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nAc*pt: sample\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "ヘッダーフィールドの値が空白のみ";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\nAccept:    \r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeContentLengthTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "Content-Lengthの検証（正常値)";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Length: 10\r\n\r\n";
+                f._httpStatus.set(http::HttpStatus::OK);
+                f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "10");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Content-Lengthが複数失敗";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\nContent-Length: 20\r\n"
+                "Content-Length: 20\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "20");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Content-Lengthが複数成功";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Length: 10, 10\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "10");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "10");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Content-Lengthが数値でない";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Length: abc\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "abc");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Content-Lengthが負の値";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Length: -10\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "-10");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Content-Lengthが複数異なる値";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\nContent-Length: 10\r\n"
+                "Content-Length: 20\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "10");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Content-Lengthにカンマ区切りで異なる値";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Length: 10, 20\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "10");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "20");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "制限を超えるContent-Length";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Length: 10000000\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::PAYLOAD_TOO_LARGE);
+    f._isSuccessTest = false;  // 413 Request Entity Too Large
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "10000000");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Content-LengthとTransfer-Encodingの両方が存在";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Length: 10\r\n"
+                "Transfer-Encoding: chunked\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "10");
+    addFieldToMap(f._exceptMap, http::fields::TRANSFER_ENCODING, "chunked");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Content-Lengthが0";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Length: 0\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "0");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeTransferEncodingTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "Transfer-Encoding: chunkedの検証";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::TRANSFER_ENCODING, "chunked");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    // gzipに対応するか検討
+    f._name = "Transfer-Encoding: chunkedとその他のエンコーディング";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Transfer-Encoding: gzip, chunked\r\n\r\n0\r\n\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::NOT_IMPLEMENTED);
+    f._isSuccessTest = false;  // 501 NOT_IMPLEMENTED
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::TRANSFER_ENCODING, "gzip");
+    addFieldToMap(f._exceptMap, http::fields::TRANSFER_ENCODING, "chunked");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "不正なTransfer-Encoding";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Transfer-Encoding: invalid\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::NOT_IMPLEMENTED);
+    f._isSuccessTest = false;  // 501 NOT IMPLEMENTED
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::TRANSFER_ENCODING, "invalid");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Transfer-Encodingが複数存在";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Transfer-Encoding: chunked\r\n"
+                "Transfer-Encoding: gzip\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::TRANSFER_ENCODING, "chunked");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "chunkedが最後にない場合";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Transfer-Encoding: chunked, gzip\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::NOT_IMPLEMENTED);
+    f._isSuccessTest = false;  // 501 NOT IMPLEMENTED
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::TRANSFER_ENCODING, "chunked");
+    addFieldToMap(f._exceptMap, http::fields::TRANSFER_ENCODING, "gzip");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeEncodingTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "Accept-Encodingヘッダー処理";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "Accept-Encoding: gzip, deflate\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::ACCEPT_ENCODING, "gzip");
+    addFieldToMap(f._exceptMap, http::fields::ACCEPT_ENCODING, "deflate");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "Content-Encodingヘッダー処理";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Encoding: gzip\r\n"
+                "Content-Length: 10\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_ENCODING, "gzip");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "10");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeServerConfigTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "サーバー名指定（server_name一致）";
+    f._request = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "localhost");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "サーバー名指定（server_name不一致）";
+    f._request = "GET / HTTP/1.1\r\nHost: unknown-server\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 OK（デフォルトサーバーで処理）
+    addFieldToMap(f._exceptMap, http::fields::HOST, "unknown-server");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "サーバー名とポート指定";
+    f._request = "GET / HTTP/1.1\r\nHost: localhost:8080\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "localhost:8080");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeCookieTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "Cookie設定検証";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "Cookie: session=abc123\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::COOKIE, "session=abc123");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "複数のCookie設定";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "Cookie: session=abc123; user=john\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::COOKIE,
+                    "session=abc123; user=john");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeCGITests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "CGI実行用のContent-Typeテスト（PHP）";
+    f._request = "POST /cgi-bin/script.php HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Type: application/x-www-form-urlencoded\r\n"
+                "Content-Length: 9\r\n\r\nkey=value";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_TYPE,
+                    "application/x-www-form-urlencoded");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "9");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "マルチパートフォームデータ";
+    f._request = "POST / HTTP/1.1\r\nHost: sample\r\n"
+                "Content-Type: multipart/form-data; boundary=boundary\r\n"
+                "Content-Length: 10\r\n\r\n";
+        f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_TYPE,
+                    "multipart/form-data; boundary=boundary");
+    addFieldToMap(f._exceptMap, http::fields::CONTENT_LENGTH, "10");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeDateHeaderTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "正しい形式のDateヘッダー";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "Date: Fri, 15 May 2023 12:30:45 GMT\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::DATE, "Fri");
+    addFieldToMap(f._exceptMap, http::fields::DATE, "15 May 2023 12:30:45 GMT");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeServerHeaderTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "基本的なServerヘッダー";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "Server: Apache/2.4.41 (Unix)\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::SERVER, "Apache/2.4.41 (Unix)");
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "複雑なServerヘッダー";
+    f._request = "GET / HTTP/1.1\r\nHost: sample\r\n"
+                "Server: Apache/2.4.41 (Unix) OpenSSL/1.1.1d PHP/7.4.3\r\n\r\n";
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    addFieldToMap(f._exceptMap, http::fields::HOST, "sample");
+    addFieldToMap(f._exceptMap, http::fields::SERVER,
+                    "Apache/2.4.41 (Unix) OpenSSL/1.1.1d PHP/7.4.3");
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void makeLargeRequestTests(TestVector& tests) {
+    FieldTest f;
+
+    f._name = "非常に長いヘッダー値正常値";
+    {
+        std::string longValue = "";
+        for (int i = 0; i < 8186; ++i) {  // [Host: ]+ 8186 = 8kb
+            longValue += "a";
+        }
+        f._request = "GET / HTTP/1.1\r\nHost: " + longValue + "\r\n\r\n";
+        addFieldToMap(f._exceptMap, http::fields::HOST, longValue);
+    }
+    f._httpStatus.set(http::HttpStatus::OK);
+    f._isSuccessTest = true;  // 200 http::OK
+    tests.push_back(f);
+    f._exceptMap.clear();
+
+    f._name = "非常に長いヘッダー値異常値";
+    {
+        std::string longValue = "";
+        for (int i = 0; i < 8193; ++i) {
+            longValue += "a";
+        }
+        f._request = "GET / HTTP/1.1\r\nHost: " + longValue + "\r\n\r\n";
+    }
+    f._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    f._isSuccessTest = false;  // 400 Bad Request
+    tests.push_back(f);
+    f._exceptMap.clear();
+}
+
+void fieldTest() {
+    TestVector tests;
+
+    makeBasicFieldTests(tests);
+    makeInvalidFieldTests(tests);
+    makeHostHeaderTests(tests);
+    makeSpecialCharacterTests(tests);
+    makeDelimiterTests(tests);
+    makeContentLengthTests(tests);
+    makeTransferEncodingTests(tests);
+    makeEncodingTests(tests);
+    makeServerConfigTests(tests);
+    makeCookieTests(tests);
+    makeCGITests(tests);
+    makeDateHeaderTests(tests);
+    makeServerHeaderTests(tests);
+    makeLargeRequestTests(tests);
+    int pass = 0;
+    for (std::size_t i = 0; i < tests.size(); ++i) {
+        if (runTest(tests[i])) {
+            ++pass;
+        }
+    }
+    std::cout << "Field testcase " << pass << " / "
+        << tests.size() << std::endl;
+}

--- a/test/http/request_parse/request_buf_size_test.cpp
+++ b/test/http/request_parse/request_buf_size_test.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <cassert>
+#include "../../../src/http/request/request_parser.hpp"
+
+std::string statusToString(http::BaseParser::ParseStatus status);
+
+void testRequestParser() {
+    http::RequestParser parser;
+    std::string request =
+        "GET /index.html HTTP/1.1\r\n"
+        "Host: example.com\r\n"
+        "Content-Length: 13\r\n"
+        "\r\n"
+        "Hello, World!";
+    const size_t BUFFER_SIZE = 10;
+
+    size_t pos = 0;
+    http::BaseParser::ParseStatus status = http::BaseParser::P_IN_PROGRESS;
+
+    std::cout << "===== テスト開始 =====\n";
+
+    while (pos < request.size() && status != http::BaseParser::P_ERROR) {
+        size_t chunk_size = std::min(BUFFER_SIZE, request.size() - pos);
+        std::string chunk = request.substr(pos, chunk_size);
+        pos += chunk_size;
+
+        status = parser.run(chunk);
+
+        // std::cout << "チャンク処理: [" << chunk << "]\n";
+        // std::cout << "ステータス: " << statusToString(status) << "\n";
+
+        if (status == http::BaseParser::P_COMPLETED) {
+            http::HTTPRequest& req = parser.get();
+            std::cout << "パース完了:\n";
+            std::cout << "  メソッド: " << req.method << "\n";
+            std::cout << "  URI: " << req.uri.fullUri << "\n";
+            std::cout << "  バージョン: " << req.version << "\n";
+            std::cout << "  ホスト: " << req.fields.getFieldValue("Host")[0] << "\n";
+            std::cout << "  ボディ: " << req.body.content << "\n";
+
+            assert(req.method == "GET");
+            assert(req.uri.fullUri == "/index.html");
+            assert(req.version == "HTTP/1.1");
+            assert(req.fields.getFieldValue("Host")[0] == "example.com");
+            assert(req.body.content == "Hello, World!");
+        } else if (status == http::BaseParser::P_ERROR) {
+            std::cout << "エラー発生: HTTPステータス " 
+                      << parser.get().httpStatus.get() << "\n";
+        }
+    }
+
+    std::cout << "===== テスト終了 =====\n";
+    if (status == http::BaseParser::P_COMPLETED) {
+        std::cout << "テスト成功: リクエストが正しく解析されました\n";
+    } else {
+        std::cout << "テスト失敗: リクエストの解析が完了しませんでした\n";
+    }
+}
+
+std::string statusToString(http::BaseParser::ParseStatus status) {
+    switch (status) {
+        case http::BaseParser::P_IN_PROGRESS:
+            return "処理中";
+        case http::BaseParser::P_NEED_MORE_DATA:
+            return "データ不足";
+        case http::BaseParser::P_COMPLETED:
+            return "完了";
+        case http::BaseParser::P_ERROR:
+            return "エラー";
+        default:
+            return "不明";
+    }
+}

--- a/test/http/request_parse/requestline_test.hpp
+++ b/test/http/request_parse/requestline_test.hpp
@@ -1,0 +1,31 @@
+// Copyright 2025 Ideal Broccoli
+
+#pragma once
+
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+
+#include "../../../src/http/request/http_fields.hpp"
+#include "../../../src/http/http_namespace.hpp"
+#include "../../../src/http/http_status.hpp"
+#include "base_test.hpp"
+
+typedef std::pair<std::string, std::string> QueryPair;
+typedef std::vector<QueryPair> QueryVec;
+typedef std::map<std::string, std::string> QueryMap;  // 修正予定
+
+class RequestLineTest : public BaseTest {
+ public:
+    struct ExceptRequestLine {
+        std::string method;
+        std::string path;
+        QueryVec queryVec;
+        std::string version;
+    };
+    RequestLineTest() : BaseTest() {}
+    ~RequestLineTest() {}
+
+    ExceptRequestLine _exceptRequest;
+};

--- a/test/http/request_parse/requestline_testcase.cpp
+++ b/test/http/request_parse/requestline_testcase.cpp
@@ -1,0 +1,975 @@
+// Copyright 2025 Ideal Broccoli
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include <cstdio>
+
+#include "../../../toolbox/stepmark.hpp"
+#include "requestline_test.hpp"
+#include "../../../src/http/request/request_parser.hpp"
+
+typedef std::vector<RequestLineTest> TestVector;
+
+bool compareRequestLine(http::RequestParser& r, RequestLineTest& t) {
+    if (r.get().httpStatus.get() != t._httpStatus.get()) {
+        return false;
+    }
+    if (r.get().method != t._exceptRequest.method ||
+        r.get().uri.path != t._exceptRequest.path ||
+        r.get().version != t._exceptRequest.version) {
+        return false;
+    }
+    for (std::size_t i = 0; i < t._exceptRequest.queryVec.size(); ++i) {
+        QueryMap::iterator it =
+            r.get().uri.queryMap.find(t._exceptRequest.queryVec[i].first);
+        if (it->second != t._exceptRequest.queryVec[i].second) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void showRequestLine(http::RequestParser& r, RequestLineTest& t) {
+    std::cout << "---- request -----" << std::endl;
+    std::cout << t._request << std::endl;
+    std::cout << "webserv status: " << r.get().httpStatus.get() << std::endl;
+    std::cout << "nginx status  : " << t._httpStatus.get() << std::endl;
+    std::cout << "***** method *****" << std::endl;
+    printf("webserv [%s]\nnginx   [%s]\n",
+        r.get().method.c_str(), t._exceptRequest.method.c_str());
+    std::cout << "**** path *****" << std::endl;
+    printf("webserv [%s]\nnginx   [%s]\n",
+        r.get().uri.path.c_str(), t._exceptRequest.path.c_str());
+    std::cout << "***** version *****" << std::endl;
+    printf("webserv [%s]\nnginx   [%s]\n",
+        r.get().version.c_str(), t._exceptRequest.version.c_str());
+    std::cout << "***** query *****" << std::endl;
+    for (std::size_t i = 0; i < t._exceptRequest.queryVec.size(); ++i) {
+        QueryPair pair_t = t._exceptRequest.queryVec[i];
+        QueryMap::iterator it_r = r.get().uri.queryMap.find(pair_t.first);
+        printf("webserv %s: %s\nnginx   %s: %s\n",
+            it_r->first.c_str(), it_r->second.c_str(),
+            pair_t.first.c_str(), pair_t.second.c_str());
+    }
+}
+
+bool runTest(RequestLineTest& t) {
+    toolbox::logger::StepMark::debug(t._name);
+    http::RequestParser r;
+    try {
+        r.run(t._request);
+    } catch (std::exception& e) {
+    }
+    if (t._isSuccessTest && compareRequestLine(r, t)) {
+        return true;
+    } else if (t._isSuccessTest && !compareRequestLine(r, t)) {
+        std::cout << "==== Failed: true->false " << t._name
+                  << " ====" << std::endl;
+        std::cout << t._request;
+        showRequestLine(r, t);
+        return false;
+    } else if (!t._isSuccessTest && compareRequestLine(r, t)) {
+        return true;
+    } else {
+        std::cout << "==== Failed: false->true " << t._name
+                  << " ====" << std::endl;
+        std::cout << t._request;
+        showRequestLine(r, t);
+        return false;
+    }
+    return false;
+}
+
+void clearUri(RequestLineTest& r) {
+    r._exceptRequest.method.clear();
+    r._exceptRequest.path.clear();
+    r._exceptRequest.version.clear();
+    r._exceptRequest.queryVec.clear();
+}
+
+void makeMethodTests(TestVector& t) {
+    RequestLineTest r;
+
+    r._name = "基本的なGETリクエスト";
+    r._request = "GET / HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "基本的なHEADリクエスト";
+    r._request = "HEAD /submit HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "HEAD";
+    r._exceptRequest.path = "/submit";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "基本的なPOSTリクエスト";
+    r._request = "POST /submit HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "POST";
+    r._exceptRequest.path = "/submit";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "基本的なDELETEリクエスト";
+    r._request = "DELETE /resource HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "DELETE";
+    r._exceptRequest.path = "/resource";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "大文字小文字混在メソッド";
+    r._request = "gEt / HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "gEt";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "空のメソッド";
+    r._request = " / HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+}
+
+void makePathTests(TestVector& t) {
+    RequestLineTest r;
+
+    r._name = "基本的なパス";
+    r._request = "GET / HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "複雑なパス";
+    r._request = "GET /path1/path2/path3/index.html HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/path1/path2/path3/index.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "特殊文字を含むパス";
+    r._request = "GET /file-name_with.special+chars HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/file-name_with.special+chars";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "空のパス";
+    r._request = "GET  HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "HTTP/1.1";
+    r._exceptRequest.version = "";
+    t.push_back(r);
+    clearUri(r);
+
+    std::string longPath = "/";
+    for (int i = 0; i < 8192; ++i) {
+        longPath += "a";
+    }
+    r._name = "非常に長いURI";  // 8kb8192
+    r._request = "GET " + longPath + " HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::URI_TOO_LONG);  // URI Too Long
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = longPath;
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+}
+
+void makeDirectoryTraversalTests(TestVector& t) {
+    RequestLineTest r;
+
+    r._name = "基本的なディレクトリトラバーサル";
+    r._request = "GET /../etc/passwd HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/../etc/passwd";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "複数レベルのディレクトリトラバーサル";
+    r._request = "GET /images/../../etc/passwd HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/images/../../etc/passwd";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "複雑なディレクトリトラバーサル";
+    r._request = "GET /a/b/c/../../../etc/passwd HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);  // 200
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/etc/passwd";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+}
+
+void makePathNormalizationTests(TestVector& t) {
+    RequestLineTest r;
+
+    r._name = "カレントディレクトリ表記あり";
+    r._request = "GET /./index.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/index.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "複数のカレントディレクトリ表記";
+    r._request = "GET /./././index.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/index.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "親ディレクトリと現在のディレクトリの組み合わせ";
+    r._request = "GET /a/b/../c/./d HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/a/c/d";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "複数のスラッシュ";
+    r._request = "GET ////index.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/index.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "中間に複数のスラッシュ";
+    r._request = "GET /path1////path2///path3 HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/path1/path2/path3";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "末尾のスラッシュ";
+    r._request = "GET /path1/path2/ HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/path1/path2/";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "末尾の複数スラッシュ";
+    r._request = "GET /path1/path2/// HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/path1/path2/";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "複雑なパス正規化";
+    r._request = "GET /a/./b////../c/./d///.//e HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/a/c/d/e";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+}
+
+void makeMultipleDotPathTests(TestVector& t) {
+    RequestLineTest r;
+
+    r._name = "3つのドットを含むパス";
+    r._request = "GET /... HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/...";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "ファイル名に3つのドットを含むパス";
+    r._request = "GET /file... HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/file...";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "ディレクトリ名に3つのドットを含むパス";
+    r._request = "GET /dir.../file.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/dir.../file.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "4つのドットを含むパス";
+    r._request = "GET /.... HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/....";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "ドット3つと親ディレクトリ参照の混合";
+    r._request = "GET /abc/.../.. HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/abc";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "拡張子に3つのドットを含むパス";
+    r._request = "GET /file.... HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/file....";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "複数のドットを含む複雑なパス";
+    r._request = "GET /a.../b.../c.../index.html HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/a.../b.../c.../index.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+}
+
+void makeQueryParameterTests(TestVector& t) {
+    RequestLineTest r;
+
+    r._name = "単一クエリパラメータ";
+    r._request = "GET /search?q=test HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/search";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.queryVec.push_back(QueryPair("q", "test"));
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+
+    r._name = "クエリパラメータ?連続";
+    r._request = "GET /search???q=test HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/search";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.queryVec.push_back(QueryPair("??q", "test"));
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+
+    r._name = "複数クエリパラメータ";
+    r._request = "GET /search?q=test&page=1&limit=10 HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/search";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.queryVec.push_back(QueryPair("q", "test"));
+    r._exceptRequest.queryVec.push_back(QueryPair("page", "1"));
+    r._exceptRequest.queryVec.push_back(QueryPair("limit", "10"));
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+
+    r._name = "空の値を持つクエリパラメータ";
+    r._request = "GET /search?q= HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/search";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.queryVec.push_back(QueryPair("q", ""));
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+
+    r._name = "フラグメント";
+    r._request = "GET /page#section1 HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/page";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "クエリパラメータとフラグメント";
+    r._request = "GET /page?id=123#section1 HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/page";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.queryVec.push_back(QueryPair("id", "123"));
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+
+    r._name = "フラグメントの後にクエリが存在する場合";
+    r._request = "GET /page#section1?id=123 HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/page";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+}
+
+void makeHttpVersionTests(TestVector& t) {
+    RequestLineTest r;
+
+    r._name = "HTTP/1.1";
+    r._request = "GET / HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "HTTP/1.0";  // 対応するかどうか決める
+    r._request = "GET / HTTP/1.0\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "HTTP/1.0";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "不正なHTTPバージョン";
+    r._request = "GET / HTTP/2.0\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::HTTP_VERSION_NOT_SUPPORTED);
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "HTTP/2.0";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "小文字HTTPバージョン";
+    r._request = "GET / http/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "http/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "空のHTTPバージョン";
+    r._request = "GET / \r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // OK
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "";
+    t.push_back(r);
+    clearUri(r);
+}
+
+void makeRequestStructureTests(TestVector& t) {
+    RequestLineTest r;
+
+    r._name = "余分なスペース";
+    r._request = "GET  /  HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "不完全なリクエストライン";
+    r._request = "GET /\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "タブ区切り";
+    r._request = "GET\t/\tHTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "";
+    r._exceptRequest.path = "";
+    r._exceptRequest.version = "";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "余分な行続き";
+    r._request = "GET / HTTP/1.1 extra\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+}
+
+void makePercentEncodingTests(TestVector& t) {
+    RequestLineTest r;
+
+    r._name = "基本的なパーセントエンコーディング";
+    r._request = "GET /hello%20world HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/hello world";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "?パーセントエンコーディング";
+    r._request = "GET /hello%3fworld HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/hello?world";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "エンコードされたGETメソッド";
+    r._request = "%47%45%54 /index.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);
+    r._exceptRequest.method = "%47%45%54";
+    r._exceptRequest.path = "/index.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._isSuccessTest = false;
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "部分的にエンコードされたPOSTメソッド";
+    r._request = "P%4FST /form.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "P%4FST";
+    r._exceptRequest.path = "/form.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "空白文字をエンコードしたメソッド";
+    r._request = "GET%20 /index.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET%20";
+    r._exceptRequest.path = "/index.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "パーセントエンコーディングされた特殊文字";
+    r._request = "GET /file%3Fname%3Dvalue%26id%3D123 HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/file?name=value&id=123";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+
+
+    r._name = "URLとクエリ文字列両方にエンコーディング";
+    r._request = "GET /search%20page?q=hello%20world&lang=ja%2Den HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/search page";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.queryVec.push_back(QueryPair("q", "hello world"));
+    r._exceptRequest.queryVec.push_back(QueryPair("lang", "ja-en"));
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+
+    r._name = "16進数の大文字小文字混在";
+    r._request = "GET /test%2a%2A%2d%2D HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/test**--";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "複数バイト文字のエンコーディング";
+    r._request = "GET /%E6%97%A5%E6%9C%AC%E8%AA%9E HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/日本語";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "エンコーディングされたスラッシュ";
+    r._request = "GET /path1%2Fpath2%2Ffile.html HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/path1/path2/file.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "エンコーディングされたドット";
+    r._request = "GET /path1%2E%2Epath2%2Efile%2Ehtml HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/path1..path2.file.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "パーセント記号自体のエンコーディング";
+    r._request = "GET /discount%2550%25 HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/discount%50%";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "不完全なパーセントエンコーディング（16進数1桁）";
+    r._request = "GET /test%3 HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/test%3";  // need check
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "パーセント記号の後に16進数以外の文字";
+    r._request = "GET /test%XY HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/test%XY";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "エンコーディングされたNULL文字";
+    r._request = "GET /test%00.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/test%00.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "エンコーディングされた制御文字";
+    r._request = "GET /test%0A%0D.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);  // will Not Found
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/test\n\r.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "エンコードされたディレクトリトラバーサル";
+    r._request = "GET /%2e%2e/%2e%2e/etc/passwd HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/../../etc/passwd";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "クエリ文字列内の+記号（スペースを表す）";
+    r._request = "GET /search?q=hello+world HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/search";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.queryVec.push_back(QueryPair("q", "hello+world"));
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+
+    r._name = "パス内の+記号（+記号そのもの）";
+    r._request = "GET /file+name.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/file+name.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "エンコードされたURLスキーム";
+    r._request = "GET /redirect?url=http%3A%2F%2Fexample.com HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/redirect";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.queryVec.push_back(QueryPair("url", "http://example.com"));
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+
+    std::string longEncodedPath = "/";
+    for (int i = 0; i < 8192; ++i) {
+        longEncodedPath += "%41";
+    }
+    r._name = "非常に長いエンコードされたパス";
+    r._request = "GET " + longEncodedPath + " HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::URI_TOO_LONG);  // URI Too Long
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = longEncodedPath;
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "エンコードされたリクエストラインの全要素";
+    r._request = "%47%45%54 %2F%69%6E%64%65%78%2E%68%74%6D%6C "
+                    "%48%54%54%50%2F%31%2E%31\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "%47%45%54";
+    r._exceptRequest.path = "%2F%69%6E%64%65%78%2E%68%74%6D%6C";
+    r._exceptRequest.version = "%48%54%54%50%2F%31%2E%31";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "エンコードされた日本語のパス";
+    r._request = "GET /%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB.html HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/ファイル.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "パス中の特殊文字の複合エンコーディング";
+    r._request = "GET /path/%3C%3E%22%27%60%7B%7D%5B%5D%5C%7C "
+                    "HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/path/<>\"'`{}[]\\|";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "URIエンコードされたディレクトリ区切り文字の特殊ケース";
+    r._request = "GET /dir%2F..%2Fsecret.txt HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);  // will Not Found
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/secret.txt";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "マルチレベルエンコードURIのディレクトリトラバーサル";
+    r._request = "GET /safe/..%2F..%2F..%2Fetc%2Fpasswd HTTP/1.1\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/safe/../../../etc/passwd";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "Unicode正規化考慮のURI";
+    r._request = "GET /caf%C3%A9.html HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/café.html";
+    r._exceptRequest.version = "HTTP/1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "エンコードされたHTTPバージョン";
+    r._request = "GET /index.html %48%54%54%50%2F%31%2E%31\r\n"
+                    "Host: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/index.html";
+    r._exceptRequest.version = "%48%54%54%50%2F%31%2E%31";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "部分的にエンコードされたHTTPバージョン";
+    r._request = "GET /index.html HTTP%2F1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/index.html";
+    r._exceptRequest.version = "HTTP%2F1.1";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "数字をエンコードしたHTTPバージョン";
+    r._request = "GET /index.html HTTP/%31.%31\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::BAD_REQUEST);  // Bad Request
+    r._isSuccessTest = false;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/index.html";
+    r._exceptRequest.version = "HTTP/%31.%31";
+    t.push_back(r);
+    clearUri(r);
+
+    r._name = "複合的なエンコーディングケース";
+    r._request = "GET /path%20with%20spaces.php?param=%22quoted%22&japanese"
+            "=%E6%97%A5%E6%9C%AC%E8%AA%9E HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/path with spaces.php";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.queryVec.push_back(QueryPair("param", "\"quoted\""));
+    r._exceptRequest.queryVec.push_back(QueryPair("japanese", "日本語"));
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+
+    r._name = "混合エンコーディング queryの+をSP(対応しない)";
+    r._request = "GET /path/with/mixed%20encoding+and+plus?"
+                "q=test%20query+with+spaces HTTP/1.1\r\nHost: sample\r\n\r\n";
+    r._httpStatus.set(http::HttpStatus::OK);
+    r._isSuccessTest = true;
+    r._exceptRequest.method = "GET";
+    r._exceptRequest.path = "/path/with/mixed encoding+and+plus";
+    r._exceptRequest.version = "HTTP/1.1";
+    r._exceptRequest.queryVec.push_back(
+                                QueryPair("q", "test query+with+spaces"));
+    t.push_back(r);
+    clearUri(r);
+    r._exceptRequest.queryVec.clear();
+}
+
+void requestLineTest() {
+    TestVector tests;
+    makeMethodTests(tests);
+    makePathTests(tests);
+    makeDirectoryTraversalTests(tests);
+    makePathNormalizationTests(tests);
+    makeMultipleDotPathTests(tests);
+    makeQueryParameterTests(tests);
+    makeHttpVersionTests(tests);
+    makeRequestStructureTests(tests);
+    makePercentEncodingTests(tests);
+
+    std::size_t pass = 0;
+    for (std::size_t i = 0; i < tests.size(); ++i) {
+        if (runTest(tests[i])) {
+            ++pass;
+        }
+    }
+    std::cout << "RequestLine testcase " << pass << " / "
+        << tests.size() << std::endl;
+}

--- a/test/http/request_parse/test_main.cpp
+++ b/test/http/request_parse/test_main.cpp
@@ -1,0 +1,17 @@
+// Copyright 2025 Ideal Broccoli
+
+#include "../../../toolbox/stepmark.hpp"
+
+void requestLineTest();
+void fieldTest();
+void testRequestParser();
+
+int main(void) {
+    toolbox::logger::StepMark::setLogFile("request_test.log");
+    toolbox::logger::StepMark::setLevel(toolbox::logger::DEBUG);
+    requestLineTest();
+    fieldTest();
+    testRequestParser();
+
+    return 0;
+}


### PR DESCRIPTION
## 概要

rename test/http/request/ to test/http/request_parse/

## 変更内容

* test/http/request/をtest/http/request_parse/に変更した
  * Requestクラスのテストを作るディレクトリがなかったため、request_parseのクラスのテストのディレクトリの名前を変えた

## 関連Issue

* #116

## 影響範囲

* リクエストパースのテスト

## テスト

* リクエストパースのテストがこれまで通り動けばOK

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Test | HTTPリクエスト解析のための新しいテストディレクトリとテストケースが追加されました。 |
| Refactor | テストディレクトリ名が`test/http/request/`から`test/http/request_parse/`に変更され、Makefileが更新されました。 |

このプルリクエストでは、HTTPリクエスト解析のテストを強化するための新しいテストケースと構造が導入されており、コードの保守性とテストカバレッジが向上しています。特に、テストクラスの設計がしっかりしており、再利用性が高い点が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->