### PR TITLE
Update request.hpp

### DIFF
--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -32,7 +32,7 @@ class Request {
     bool recvRequest();
 
     void setLocalRedirectInfo(const std::string& method, 
-        const std::string& path, const std::string& host)
+        const std::string& path, const std::string& host);
 
     /**
     * @brief Fetches the configuration for the current request.


### PR DESCRIPTION
## 概要

セミコロンをつけた

## 変更内容

* request.hppの行末にセミコロンがない行があったので、つけた

## 関連Issue

* 

## 影響範囲

* 

## テスト

* 

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Bug fix | `Request`クラスのメンバ関数`setLocalRedirectInfo`の宣言にセミコロンを追加し、構文エラーを修正しました。 |

このプルリクエストは、コードの安定性と信頼性を向上させるための重要な修正を含んでいます。細かい部分まで注意を払い、構文エラーを迅速に解決した点が素晴らしいです。このような細部への配慮がプロジェクト全体の品質向上につながります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->