### PR TITLE
124 implement constructor & destructor of Request

### DIFF
--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -15,7 +15,7 @@ class Request {
      * @param client A shared pointer to the Client object
      * associated with this request.
      */
-    Request(toolbox::SharedPtr<Client> client, std::size_t requestDepth = 0);
+    Request(const toolbox::SharedPtr<Client>& client, std::size_t requestDepth = 0);
 
     /**
      * @brief Destructor for the Request object.

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -13,6 +13,7 @@ class Request {
     /**
      * @brief Constructs a Request object with the given client.
      * @param client A shared pointer to the Client object
+     * @param requestDepth The depth of the request, used to track local redirects
      * associated with this request.
      */
     Request(const toolbox::SharedPtr<Client>& client, std::size_t requestDepth = 0);

--- a/src/http/request/request_impl_basic.cpp
+++ b/src/http/request/request_impl_basic.cpp
@@ -1,0 +1,10 @@
+#include "request.hpp"
+
+#include "../../../toolbox/shared.hpp"
+
+http::Request::Request(toolbox::SharedPtr<Client> client, std::size_t requestDepth)
+    : _client(client), _requestDepth(requestDepth) {
+}
+
+http::Request::~Request() {
+}

--- a/src/http/request/request_impl_basic.cpp
+++ b/src/http/request/request_impl_basic.cpp
@@ -2,7 +2,7 @@
 
 #include "../../../toolbox/shared.hpp"
 
-http::Request::Request(toolbox::SharedPtr<Client> client, std::size_t requestDepth)
+http::Request::Request(const toolbox::SharedPtr<Client>& client, std::size_t requestDepth)
     : _client(client), _requestDepth(requestDepth) {
 }
 


### PR DESCRIPTION
## 概要

## 変更内容

* Requestクラスのコンストラクタを実装した 
* コンストラクタの時点で初期化しておいて欲しいものがあれば教えてください

## 関連Issue

* #124 

## 影響範囲

* Requestクラス

## テスト

* 特にないです。色々出来上がってからまとめてテストしてもいいような気がします。

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | `http::Request`クラスのコンストラクタがリファクタリングされ、`toolbox::SharedPtr<Client>`のパラメータが非constからconst参照に変更されました。 |
| Refactor | `http::Request`クラスにコンストラクタとデストラクタが追加され、メンバ変数の初期化が改善されました。 |

このプルリクエストでは、コードの可読性と保守性を向上させるために、コンストラクタのパラメータを適切に定義し、オブジェクトの不変性を保証する工夫がされています。素晴らしい改善です！
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->