### PR TITLE
130 add getter of status

### DIFF
--- a/src/http/response/response.cpp
+++ b/src/http/response/response.cpp
@@ -146,4 +146,8 @@ std::string Response::getStatusMessage(int code) {
     }
 }
 
+int Response::getStatus() const {
+    return _status;
+}
+
 }  // namespace http

--- a/src/http/response/response.hpp
+++ b/src/http/response/response.hpp
@@ -35,6 +35,8 @@ class Response {
     void sendResponse(int client_fd) const;
     static std::string getStatusMessage(int code);
 
+    int getStatus() const;
+
  private:
     int _status;
     std::map<FieldName, HeaderField> _headers;


### PR DESCRIPTION
## 概要

Responseクラスにstatusのgetterを追加する

## 変更内容

* Responseクラスにstatusのgetterを追加する
  * このstatusは、AccessLogやerror pageに使われる

## 関連Issue

* #130

## 影響範囲

* Responseクラス

## テスト

* 単純な変更なので特になし

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | `Response`クラスに`getStatus()`メソッドが追加され、ステータスコードへのアクセスが可能になりました。これにより、AccessLogやエラーページでの利用が容易になります。 |

このプルリクエストでは、`Response`クラスのインターフェースを拡張し、外部からのステータスコードの取得を可能にすることで、システム全体の柔軟性と保守性が向上しました。特に、ログ機能やエラーハンドリングの改善に寄与する素晴らしい変更です。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->