### PR TITLE
135 responseクラスにbodyのgetterを追加する

### DIFF
--- a/src/http/response/response.cpp
+++ b/src/http/response/response.cpp
@@ -154,4 +154,8 @@ std::size_t Response::getContentLength() const {
     return _body.size();
 }
 
+std::string Response::getBody() const {
+    return _body;
+}
+
 }  // namespace http

--- a/src/http/response/response.hpp
+++ b/src/http/response/response.hpp
@@ -39,6 +39,8 @@ class Response {
 
     std::size_t getContentLength() const;
 
+    std::string getBody() const;
+
  private:
     int _status;
     std::map<FieldName, HeaderField> _headers;

--- a/test/http/response/main.cpp
+++ b/test/http/response/main.cpp
@@ -68,6 +68,9 @@ int main() {
     response.sendResponse(client_fd);
     std::cout << "status: " << response.getStatus() << std::endl;
     std::cout << "Content-Length: " << response.getContentLength() << std::endl;
+    std::cout << "=== Response Body ===" << std::endl;
+    std::cout << response.getBody() << std::endl;
+    std::cout << "======================" << std::endl;
     std::cout << "Response sent to client" << std::endl;
     close(client_fd);
     close(server_fd);


### PR DESCRIPTION
## 概要

responseクラスにbodyのgetterを追加する

## 変更内容

* responseクラスにbodyのgetterを追加する
  * LocalRedirect時にリダイレクト先の情報を呼び出しもとのRequestインスタンスのResponseに反映させる時に使う

## 関連Issue

* #135

## 影響範囲

* Responseクラス

## テスト

* test/http/responseでmake後、実行ファイルを実行する。別ターミナルから`curl -i localhost:8080`を実行
* curl だけでなく、w3mなども一応実行できるみたいです

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。
