### PR TITLE
134 recvrequset条件変更refact

### DIFF
--- a/src/http/request/recv_request.cpp
+++ b/src/http/request/recv_request.cpp
@@ -10,64 +10,112 @@ namespace http {
 
 namespace {
 const std::size_t BUFFER_SIZE = 2048;
+
+int handleRecvResult(int receivedSize,
+                      BaseParser::ValidatePos validatePos,
+                      const toolbox::SharedPtr<Client>& client) {
+    int statusCode = 200;
+    if (receivedSize == 0) {
+        toolbox::logger::StepMark::info("Request: recvRequest: client "
+            "disconnected " + toolbox::to_string(client->getFd()));
+        if (validatePos != BaseParser::V_COMPLETED) {
+            statusCode = 400;
+        }
+    } else if (receivedSize == -1) {
+        toolbox::logger::StepMark::error("Request: recvRequest: recv failed "
+            "in recv from " + toolbox::to_string(client->getFd()));
+        statusCode = 500;
+    }
+    return statusCode;
 }
 
-bool Request::recvRequest() {
+bool isValidContentLength(std::size_t contentLength,
+                          std::size_t clientMaxBodySize) {
+    if (contentLength > clientMaxBodySize) {
+        toolbox::logger::StepMark::info( "Request: recvRequest: content length"
+            " exceeds client max body size");
+        return false;
+    }
+    return true;
+}
+
+bool isValidReceivedLength(std::size_t receivedLength,
+                           std::size_t clientMaxBodySize) {
+    if (receivedLength > clientMaxBodySize) {
+        toolbox::logger::StepMark::info("Request: recvRequest: received length"
+            " exceeds client max body size");
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+bool Request::performRecv(std::string& receivedData) {
     char buffer[BUFFER_SIZE];
 
-    int bytesReceived = recv(_client->getFd(), buffer, sizeof(buffer) - 1, 0);
-    if (bytesReceived == 0) {
-        toolbox::logger::StepMark::info("Request: recvRequest: client "
-            "disconnected " + toolbox::to_string(_client->getFd()));
-        if (_parsedRequest.getValidatePos() == BaseParser::V_COMPLETED) {
-            _response.setStatus(HttpStatus::OK);
-            return true;
-        } else {
-            _response.setStatus(HttpStatus::BAD_REQUEST);
-            return false;
-        }
-    } else if (bytesReceived == -1) {
-        toolbox::logger::StepMark::error("Request: recvRequest: recv failed "
-            "in recv from " + toolbox::to_string(_client->getFd()));
-        _response.setStatus(HttpStatus::INTERNAL_SERVER_ERROR);
+    int receivedSize = recv(_client->getFd(), buffer, BUFFER_SIZE - 1, 0);
+    int statusCode = handleRecvResult(receivedSize, 
+                                  _parsedRequest.getValidatePos(), _client);
+
+    if (statusCode != 200) {
+        _response.setStatus(statusCode);
         return false;
     }
 
-    _parsedRequest.run(std::string(buffer, bytesReceived));
+    buffer[receivedSize] = '\0';
+    receivedData = std::string(buffer, receivedSize);
+    return true;
+}
 
-    std::size_t clientMaxBodySize = 0;
-
-    BaseParser::ValidatePos validatePos = _parsedRequest.getValidatePos();
-    bool hasContentLength = _parsedRequest.get().body.contentLength != 
-                           std::numeric_limits<std::size_t>::max();
-
-    if ((validatePos == BaseParser::V_BODY ||
-        validatePos == BaseParser::V_COMPLETED) && hasContentLength) {
-        if (_config.getPath().empty()) {  // If path is empty, fetch the config
-            fetchConfig();
-        }
-
-        clientMaxBodySize = _config.getClientMaxBodySize();
-
-        std::size_t contentLength = _parsedRequest.get().body.contentLength;
-        if (contentLength > clientMaxBodySize) {
+bool Request::loadConfig() {
+    if (_config.getPath().empty()) {
+        fetchConfig();
+        if (_response.getStatus() != HttpStatus::OK) {
             toolbox::logger::StepMark::info(
-                "Request: recvRequest: content length exceeds "
-                "client max body size");
-            _response.setStatus(HttpStatus::PAYLOAD_TOO_LARGE);
-            return false;
-        }
-
-        std::size_t receivedLength = _parsedRequest.get().body.receivedLength;
-        if (receivedLength > clientMaxBodySize) {
-            toolbox::logger::StepMark::info(
-                "Request: recvRequest: receivedLength exceeds "
-                "client max body size");
-            _response.setStatus(HttpStatus::PAYLOAD_TOO_LARGE);
+                "Request: loadConfig: fetchConfig failed");
             return false;
         }
     }
     return true;
+}
+
+bool Request::validateBodySize() {
+    const BaseParser::ValidatePos validatePos = _parsedRequest.getValidatePos();
+    if (validatePos != BaseParser::V_BODY &&
+        validatePos != BaseParser::V_COMPLETED) {
+        return true;
+    }
+
+    if (!loadConfig()) {
+        return false;
+    }
+
+    const std::size_t clientMaxBodySize = _config.getClientMaxBodySize();
+    const std::size_t contentLength = _parsedRequest.get().body.contentLength;
+    const std::size_t receivedLength = _parsedRequest.get().body.receivedLength;
+
+    if (!isValidContentLength(contentLength, clientMaxBodySize) ||
+        !isValidReceivedLength(receivedLength, clientMaxBodySize)) {
+        _response.setStatus(HttpStatus::PAYLOAD_TOO_LARGE);
+        return false;
+    }
+    return true;
+}
+
+bool Request::recvRequest() {
+    std::string receivedData;
+
+    if (!performRecv(receivedData)) {
+        return false;
+    }
+
+    if (_parsedRequest.run(receivedData) == BaseParser::P_ERROR) {
+        _response.setStatus(_parsedRequest.get().httpStatus.get());
+        return false;
+    }
+
+    return validateBodySize();
 }
 
 }  // namespace http

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -31,6 +31,9 @@ class Request {
      * false otherwise.
      */
     bool recvRequest();
+    bool performRecv(std::string& recievedData);
+    bool loadConfig();
+    bool validateBodySize();
 
     void setLocalRedirectInfo(const std::string& method, 
         const std::string& path, const std::string& host);

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -31,9 +31,6 @@ class Request {
      * false otherwise.
      */
     bool recvRequest();
-    bool performRecv(std::string& recievedData);
-    bool loadConfig();
-    bool validateBodySize();
 
     void setLocalRedirectInfo(const std::string& method, 
         const std::string& path, const std::string& host);
@@ -64,6 +61,10 @@ class Request {
     Request(const Request& other);
     Request& operator=(const Request& other);
 
+    // recvRequest helper methods
+    bool performRecv(std::string& receivedData);
+    bool loadConfig();
+    bool validateBodySize();
 };
 
 }


### PR DESCRIPTION
## 概要
134 recvrequset条件変更refact

## 変更内容

* fetchConfigが失敗した場合_response._statusを変更する。関数呼び出し後に_statusを参照し200出ない場合に適切なハンドリングを追加した。
* 関数が大きかったため分割した。
* request.hppのprivateにヘルパー関数を追加した。一部コンフリクトが起こる可能性がある

## 関連Issue

* #110 

## 影響範囲

* src/http/request/recv_request.cpp

## テスト

* 

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | `recvRequest`関数がリファクタリングされ、コードの可読性と保守性が向上しました。新たに小さなヘルパーメソッドが追加され、エラーハンドリングが改善されています。 |

このプルリクエストでは、大きな関数を小さく分割することで、コードの管理がしやすくなり、可読性が大幅に向上しています。エラーハンドリングの改善も行われており、堅牢性が増しています。素晴らしいリファクタリングです！
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->