### PR TITLE
61-サーバーを適切なポートで適切な個数分作成する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 NAME = webserv
 
+
 # sources
 SRCS = $(wildcard toolbox/*.cpp) $(wildcard src/*/*.cpp) $(wildcard src/*/*/*.cpp)
+SRCS := $(filter-out src/http/request/recv_request.cpp, $(SRCS))
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -38,7 +38,8 @@ http {
     }
 
     server {
-        listen 8000;
+        listen 127.1.1.222:8000;
+        listen 8080;
         server_name localhost;
 
         location / {

--- a/src/core/server.cpp
+++ b/src/core/server.cpp
@@ -15,39 +15,42 @@
 
 namespace server {
 const int DEFAULT_PORT = 8080;
+const char* DEFAULT_NAME = "server";
 const char* DEFAULT_IP = "0.0.0.0";
 }
 
 Server::Server() {
     _port = server::DEFAULT_PORT;
-    _name = "server";
     _ip = server::DEFAULT_IP;
+    _name = server::DEFAULT_NAME;
     createServerSocket();
 }
 
 Server::Server(int port) {
     _port = port;
-    _name = "server";
     _ip = server::DEFAULT_IP;
+    _name = server::DEFAULT_NAME;
     createServerSocket();
 }
 
 Server::Server(int port, const std::string& ip) {
     _port = port;
-    _name = "server";
     _ip = ip;
+    _name = server::DEFAULT_NAME;
     createServerSocket();
 }
 
 Server::Server(const Server& other) {
     _port = other._port;
     _ip = other._ip;
+    _name = other._name;
 }
 
 Server& Server::operator=(const Server& other) {
     if (this != &other) {
         _port = other._port;
         _ip = other._ip;
+        _name = other._name;
     }
     return *this;
 }

--- a/src/core/server.cpp
+++ b/src/core/server.cpp
@@ -40,21 +40,6 @@ Server::Server(int port, const std::string& ip) {
     createServerSocket();
 }
 
-Server::Server(const Server& other) {
-    _port = other._port;
-    _ip = other._ip;
-    _name = other._name;
-}
-
-Server& Server::operator=(const Server& other) {
-    if (this != &other) {
-        _port = other._port;
-        _ip = other._ip;
-        _name = other._name;
-    }
-    return *this;
-}
-
 Server::~Server() {
     close(_server_sock);
 }

--- a/src/core/server.hpp
+++ b/src/core/server.hpp
@@ -4,29 +4,40 @@
 #include <fcntl.h>
 #include <exception>
 #include <string>
+#include <stdint.h> 
+
+namespace server {
+extern const int DEFAULT_PORT;
+extern const char* DEFAULT_IP;
+}  // namespace server
 
 class Server {
  public:
     class ServerException : public std::exception {
      public:
         explicit ServerException(const char* message);
+        explicit ServerException(const std::string& message);
+        virtual ~ServerException() throw();
         const char* what() const throw();
      private:
-        const char* _message;
+        std::string _message;
     };
     Server();
     explicit Server(int port);
+    Server(int port, const std::string& ip);
     Server(const Server& other);
     Server& operator=(const Server& other);
     virtual ~Server();
-    int getFd() const;
-    void setName(const std::string& name);
-    std::string getName() const;
+
+    int getFd() const { return _server_sock; }
+    void setName(const std::string& name) { _name = name; }
+    std::string getName() const { return _name; }
 
  private:
-    static const int default_port = 8080;
     int _port;
     int _server_sock;
     std::string _name;
+    std::string _ip;
     void createServerSocket();
+    uint32_t parseIpAddress(const std::string& ip) const;
 };

--- a/src/core/server.hpp
+++ b/src/core/server.hpp
@@ -26,8 +26,6 @@ class Server {
     Server();
     explicit Server(int port);
     Server(int port, const std::string& ip);
-    Server(const Server& other);
-    Server& operator=(const Server& other);
     virtual ~Server();
 
     int getFd() const { return _server_sock; }
@@ -35,6 +33,9 @@ class Server {
     std::string getName() const { return _name; }
 
  private:
+    Server(const Server& other);
+    Server& operator=(const Server& other);
+
     int _port;
     std::string _ip;
     std::string _name;

--- a/src/core/server.hpp
+++ b/src/core/server.hpp
@@ -8,6 +8,7 @@
 
 namespace server {
 extern const int DEFAULT_PORT;
+extern const char* DEFAULT_NAME;
 extern const char* DEFAULT_IP;
 }  // namespace server
 
@@ -35,9 +36,9 @@ class Server {
 
  private:
     int _port;
-    int _server_sock;
-    std::string _name;
     std::string _ip;
+    std::string _name;
+    int _server_sock;
     void createServerSocket();
     uint32_t parseIpAddress(const std::string& ip) const;
 };

--- a/test/core/server/Makefile
+++ b/test/core/server/Makefile
@@ -1,0 +1,30 @@
+NAME = server_test.out
+
+SRCS = main.cpp \
+		../../../src/core/server.cpp \
+		../../../src/core/client.cpp \
+		../../../src/event/epoll.cpp \
+		../../../toolbox/string.cpp \
+		../../../toolbox/stepmark.cpp
+OBJS = $(SRCS:.cpp=.o)
+
+CXX = c++
+CXXFLAGS = -Wall -Wextra -Werror -std=c++98
+
+run: $(NAME)
+	./$(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJS)
+
+clean:
+	rm -f $(OBJS) $(NAME)
+
+fclean: clean
+	rm -f $(NAME)
+
+re: fclean all
+
+all: $(NAME)
+
+.PHONY: all clean fclean re run

--- a/test/core/server/main.cpp
+++ b/test/core/server/main.cpp
@@ -1,0 +1,121 @@
+// this is a simple version of src/core/main.cpp
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <unistd.h>
+#include <string>
+#include <iostream>
+#include <cerrno>
+#include <cstdio>
+#include <sstream>
+
+#include "../../../src/core/server.hpp"
+#include "../../../src/core/client.hpp"
+#include "../../../src/event/epoll.hpp"
+#include "../../../src/event/tagged_epoll_event.hpp"
+#include "../../../toolbox/string.hpp"
+#include "../../../toolbox/shared.hpp"
+
+int main(void) {
+    try {
+        Epoll epoll;
+        toolbox::SharedPtr<Server> server1(new Server(3000, "127.1.1.1"));
+        server1->setName("server1");
+        epoll.addServer(server1->getFd(), server1);
+        toolbox::SharedPtr<Server> server2(new Server(5000, "0.0.0.0"));
+        server2->setName("server2");
+        epoll.addServer(server2->getFd(), server2);
+        try {
+            toolbox::SharedPtr<Server> server3(new Server(5000, "256"));
+        } catch (std::exception& e) {
+            std::cerr << e.what() << std::endl;
+        }
+        try {
+            toolbox::SharedPtr<Server> server3(new Server(5000, "256.0.0.0"));
+        } catch (std::exception& e) {
+            std::cerr << e.what() << std::endl;
+        }
+        try {
+            toolbox::SharedPtr<Server> server3(new Server(5000, "192.3.33.23"));
+        } catch (std::exception& e) {
+            std::cerr << e.what() << std::endl;
+        }
+        int cnt = 0;
+        struct epoll_event events[1000];
+        while (1) {
+            try {
+                int nfds = epoll.wait(events, 1000, -1);
+                if (nfds == -1) {
+                    throw std::runtime_error("epoll_wait failed");
+                }
+                for (int i = 0; i < nfds; i++) {
+                    taggedEventData* tagged =
+                        static_cast<taggedEventData*>(events[i].data.ptr);
+                    if (tagged->server) {
+                        try {
+                            std::cout <<"---------------   server   ---------------" <<std::endl;
+                            toolbox::SharedPtr<Server> server = tagged->server;
+                            struct sockaddr_in client_addr;
+                            socklen_t addr_len = sizeof(client_addr);
+                            int client_sock = accept(server->getFd(), (struct sockaddr*)&client_addr, &addr_len);
+                            if (client_sock == -1) {
+                                throw std::runtime_error("accept failed");
+                            }
+                            std::cout << server->getName() << " accepted client fd: " << client_sock << std::endl;
+                            toolbox::SharedPtr<Client> client(new Client(client_sock, client_addr, addr_len));
+                            epoll.addClient(client_sock, client);
+                        } catch(std::exception& e) {
+                            std::cerr << e.what() << std:: endl;
+                        }
+                    } else {
+                        try {
+                            std::cout << "--------------- client " << ++cnt << " ---------------" <<std::endl;
+                            toolbox::SharedPtr<Client> client = tagged->client;
+                            int client_sock = client->getFd();
+                            std::cout << "send response to client fd: " << client_sock << std::endl;
+                            std::cout << "client ip: " << client->getIp() << std::endl;
+                            std::cout << "server ip: " << client->getServerIp() << std::endl;
+                            std::cout << "server port: " << client->getServerPort() << std::endl;
+
+                            char buf[1024];
+                            int len = 0;
+                            std::string whole_request;
+                            do {
+                                len = recv(client_sock, buf, sizeof(buf), 0);
+                                if (len == -1) {
+                                    if (errno == EAGAIN) { //if no recv data
+                                        break;
+                                    }
+                                    throw std::runtime_error("recv failed");
+                                } else if (len == 0) {
+                                    break;
+                                } else {
+                                    whole_request.append(buf, len);
+                                }
+                            } while (len > 0);
+
+                            const char* responseHeader = "HTTP/1.1 200 OK\r\nContent-Length: ";
+                            std::string responseBody = "<html><body>hello\n" + whole_request + "</body></html>";
+                            std::string response = responseHeader + toolbox::to_string(responseBody.size()) + "\r\n\r\n" + responseBody;
+                            if (send(client_sock, response.c_str(), response.size(), 0) == -1) {
+                                throw std::runtime_error("send failed");
+                            }
+                            epoll.del(client_sock);
+                        } catch (std::exception& e) {
+                            std::cerr << e.what() << std:: endl;
+                        }
+                    }
+                }
+            } catch (std::exception& e) {
+                std::cerr << e.what() << std::endl;
+            }
+        }
+        epoll.del(server1->getFd());
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## 概要

設定ファイルに記載されているserverブロック内のlistenの個数分、サーバーを立ち上げるように修正
特定のipアドレス＋portでserverを立ち上げられるようにServerクラスにipアドレス、portの引数をもつコンストラクタを追加

## 変更内容
* Makefile
  * recv_request.cppをビルド対象から除外
* conf/default.conf
  * ipアドレスを明示
  * 3つサーバーが起動する(`*:5000`, `127.1.1.222:8000`, `*:8080`) 
* src/core/main.cpp
  * 設定ファイルに記載されているlistenディレクティブ分、Serverインスタンスを作成
  * ServerNameは常にserver_nameディレクティブに記載されている最初の値をServerクラスの_nameに設定 
* src/core/server.h/cpp
  * 特定のipアドレス＋portでserverを立ち上げられるようにServerクラスにipアドレス、portの引数をもつコンストラクタを追加
* test/core/server/main.cpp, Makefile
  * テスト用 
 
## 関連Issue

* #61

## 影響範囲

* Makefile
* conf/default.conf
* src/core/main.cpp
* src/core/server.h/cpp
* test/core/server/main.cpp, Makefile

## テスト

1. test/core/serverに移動して、 `make run`するとサーバーが起動する
以下確認
    - 不正なフォーマットのip
    - 不正な範囲のip
    - bindできないip
2. プロジェクトルートに移動して、`make` した後、`./webserv` 
以下確認
    - `lsof -i -P -n | grep webserv`
    - conf/default.confに設定した3つサーバーが表示される(`*:5000`, `127.1.1.222:8000`, `*:8080`) 

## その他

* core/main.cppに対応するMakefileでビルドエラーを防ぐため、`recv_request.cpp`を対象外としているので #73 のタイミングで修正していただく必要がある

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | 設定ファイルに基づいて複数のサーバーインスタンスを動的に作成する機能が追加されました。 |
| Refactor | `Server`クラスにIPアドレスとポートを指定できるコンストラクタが追加され、例外処理が強化されました。 |
| Test | サーバーテスト用のMakefileとテストロジックが追加され、Epollを用いたクライアント接続処理が実装されました。 |

このプルリクエストでは、サーバーの柔軟な初期化と堅牢なエラーハンドリングが実現されており、特に例外処理の強化とテスト環境の整備が素晴らしいです。これにより、開発者が安心して新機能を追加できる基盤が整いました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->