### PR TITLE
139 epollシングルトン化

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -29,20 +29,19 @@ int main(int argc, char* argv[]) {
         toolbox::SharedPtr<config::ServerConfig> serverConfig1 = httpConfig->getServers()[0];
         toolbox::SharedPtr<config::ServerConfig> serverConfig2 = httpConfig->getServers()[1];
 
-        Epoll epoll;
         toolbox::SharedPtr<Server> server1(new Server(serverConfig1->getListens()[0].getPort()));
         server1->setName(serverConfig1->getServerNames()[0].getName());
-        epoll.addServer(server1->getFd(), server1);
+        Epoll::addServer(server1->getFd(), server1);
 
         toolbox::SharedPtr<Server> server2(new Server(serverConfig2->getListens()[0].getPort()));
         server2->setName(serverConfig2->getServerNames()[0].getName());
-        epoll.addServer(server2->getFd(), server2);
+        Epoll::addServer(server2->getFd(), server2);
 
         int cnt = 0;  // for debug
         struct epoll_event events[1000];
         while (1) {
             try {
-                int nfds = epoll.wait(events, 1000, -1);
+                int nfds = Epoll::wait(events, 1000, -1);
                 if (nfds == -1) {
                     throw std::runtime_error("epoll_wait failed");
                 }
@@ -62,7 +61,7 @@ int main(int argc, char* argv[]) {
                             }
                             std::cout << server->getName() << " accepted client fd: " << client_sock << std::endl;
                             toolbox::SharedPtr<Client> client(new Client(client_sock, client_addr, addr_len));
-                            epoll.addClient(client_sock, client); // this func will throw exception
+                            Epoll::addClient(client_sock, client); // this func will throw exception
                         } catch(std::exception& e) {
                             std::cerr << e.what() << std:: endl;
                         }
@@ -116,7 +115,7 @@ int main(int argc, char* argv[]) {
                                 throw std::runtime_error("send failed");
                                 // Send exit status to client
                             }
-                            epoll.del(client_sock);
+                            Epoll::del(client_sock);
                         } catch (std::exception& e) {
                             std::cerr << e.what() << std:: endl;
                         }
@@ -126,8 +125,8 @@ int main(int argc, char* argv[]) {
                 std::cerr << e.what() << std::endl;
             }
         }
-        epoll.del(server1->getFd());
-        epoll.del(server2->getFd());
+        Epoll::del(server1->getFd());
+        Epoll::del(server2->getFd());
     } catch (std::exception& e) {
         std::cerr << e.what() << std::endl;
         return 1;

--- a/src/event/epoll.cpp
+++ b/src/event/epoll.cpp
@@ -10,7 +10,7 @@
 #include "tagged_epoll_event.hpp"
 
 namespace toolbox {
-    static void setNonBlocking(int fd);
+static void setNonBlocking(int fd);
 }
 
 Epoll::Epoll() {
@@ -51,7 +51,7 @@ void Epoll::addServer(int fd, toolbox::SharedPtr<Server> server) {
 void Epoll::addClient(int fd, toolbox::SharedPtr<Client> client) {
     Epoll& epollInstance = getInstance();
     struct epoll_event* ev = new struct epoll_event;
-    ev->events = EPOLLIN | EPOLLET;
+    ev->events = EPOLLIN;
     taggedEventData* tagged = new taggedEventData;
     tagged->client = client;
     ev->data.ptr = static_cast<void*>(tagged);

--- a/src/event/epoll.hpp
+++ b/src/event/epoll.hpp
@@ -14,18 +14,25 @@ class Epoll {
  public:
     class EpollException : public std::exception {
      public:
-        explicit EpollException(const char* message);
-        const char* what() const throw();
+         explicit EpollException(const char* message) : _message(message) {}
+         const char* what() const throw() { return _message; }
      private:
-        const char* _message;
-    };
+         const char* _message;
+     };
+
+    static void addServer(int fd, toolbox::SharedPtr<Server> server);
+    static void addClient(int fd, toolbox::SharedPtr<Client> client);
+    static void del(int fd);
+    static int wait(struct epoll_event* events, int maxevents, int timeout);
+
+ private:
     Epoll();
     ~Epoll();
-    void addServer(int fd, toolbox::SharedPtr<Server> server);
-    void addClient(int fd, toolbox::SharedPtr<Client> client);
-    void del(int fd);
-    int wait(struct epoll_event* events, int maxevents, int timeout);
- private:
+    Epoll(const Epoll&) {};
+    Epoll& operator=(const Epoll&) { return *this; }
+
+    static Epoll& getInstance();
+
     int _epfd;
     std::map<int, struct epoll_event*> _events;
 };

--- a/test/core/client/main.cpp
+++ b/test/core/client/main.cpp
@@ -20,19 +20,18 @@
 
 int main(void) {
     try {
-        Epoll epoll;
         toolbox::SharedPtr<Server> server1(new Server(3000));
         server1->setName("server1");
-        epoll.addServer(server1->getFd(), server1);
+        Epoll::addServer(server1->getFd(), server1);
         toolbox::SharedPtr<Server> server2(new Server(5000));
         server2->setName("server2");
-        epoll.addServer(server2->getFd(), server2);
+        Epoll::addServer(server2->getFd(), server2);
 
         int cnt = 0;
         struct epoll_event events[1000];
         while (1) {
             try {
-                int nfds = epoll.wait(events, 1000, -1);
+                int nfds = Epoll::wait(events, 1000, -1);
                 if (nfds == -1) {
                     throw std::runtime_error("epoll_wait failed");
                 }
@@ -51,7 +50,7 @@ int main(void) {
                             }
                             std::cout << server->getName() << " accepted client fd: " << client_sock << std::endl;
                             toolbox::SharedPtr<Client> client(new Client(client_sock, client_addr, addr_len));
-                            epoll.addClient(client_sock, client);
+                            Epoll::addClient(client_sock, client);
                         } catch(std::exception& e) {
                             std::cerr << e.what() << std:: endl;
                         }
@@ -88,7 +87,7 @@ int main(void) {
                             if (send(client_sock, response.c_str(), response.size(), 0) == -1) {
                                 throw std::runtime_error("send failed");
                             }
-                            epoll.del(client_sock);
+                            Epoll::del(client_sock);
                         } catch (std::exception& e) {
                             std::cerr << e.what() << std:: endl;
                         }
@@ -98,7 +97,7 @@ int main(void) {
                 std::cerr << e.what() << std::endl;
             }
         }
-        epoll.del(server1->getFd());
+        Epoll::del(server1->getFd());
     } catch (std::exception& e) {
         std::cerr << e.what() << std::endl;
         return 1;


### PR DESCRIPTION
## 概要
139 epollシングルトン化

## 変更内容

* epollの操作関数をstaticにしシングルトン化した
* clientをaddする際にepollのオプションにEPOLLETが指定されていたが、エッジトリガの場合初回1回しか通知されず、recvBufを超える場合に不具合が出るため削除した。

## 関連Issue

* #5 

## 影響範囲

* src/event/

## テスト

* test/core/client　2つのポートが以前と同様に動くか確認お願いします

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | `Epoll`クラスがシングルトンパターンを実装するようにリファクタリングされ、メソッドが静的メソッドとして変更されました。 |
| Refactor | `EPOLLET`オプションが削除され、エッジトリガからレベルトリガに変更されました。 |
| Refactor | `EpollException`クラスがインラインコンストラクタと`what()`メソッドで更新されました。 |

このプルリクエストでは、`Epoll`クラスの設計が大幅に改善され、シングルトンパターンの導入によりコードの一貫性と保守性が向上しました。また、エッジトリガからレベルトリガへの変更は、予期しない動作を防ぐための賢明な選択です。素晴らしい仕事です！
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->