### PR TITLE
142 読み取り書き込みサイズを定める

### DIFF
--- a/src/core/constant.hpp
+++ b/src/core/constant.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <cstddef>
+
+namespace core {
+    const std::size_t IO_BUFFER_SIZE = 16 * 1024; // 16 KB
+}

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -11,6 +11,7 @@
 
 #include "server.hpp"
 #include "client.hpp"
+#include "constant.hpp"
 #include "../config/config_namespace.hpp"
 #include "../config/config_parser.hpp"
 #include "../event/epoll.hpp"
@@ -73,11 +74,11 @@ int main(int argc, char* argv[]) {
                             int client_sock = client->getFd();
                             std::cout << "send response to client fd: " << client_sock << std::endl;
 
-                            char buf[1024];
+                            char buf[core::IO_BUFFER_SIZE];
                             int len = 0;
                             std::string whole_request;
                             do {
-                                len = recv(client_sock, buf, sizeof(buf), 0);
+                                len = recv(client_sock, buf, core::IO_BUFFER_SIZE, 0);
                                 if (len == -1) {
                                     if (errno == EAGAIN) { //if no recv data
                                         break;
@@ -112,7 +113,7 @@ int main(int argc, char* argv[]) {
                             const char* responseHeader = "HTTP/1.1 200 OK\r\nContent-Length: ";
                             std::string responseBody = "<html><body>hello" + whole_request + "</body></html>";
                             std::string response = responseHeader + toolbox::to_string(responseBody.size()) + "\r\n\r\n" + responseBody;
-                            if (send(client_sock, response.c_str(), response.size(), 0) == -1) {
+                            if (send(client_sock, response.c_str(), response.size(), 0) == -1) { // this will be deleted later
                                 throw std::runtime_error("send failed");
                                 // Send exit status to client
                             }

--- a/src/http/request/recv_request.cpp
+++ b/src/http/request/recv_request.cpp
@@ -3,19 +3,16 @@
 
 #include "../../../toolbox/stepmark.hpp"
 #include "../../core/client.hpp"
+#include "../../core/constant.hpp"
 #include "request_parser.hpp"
 #include "request.hpp"
 
 namespace http {
 
-namespace {
-const std::size_t BUFFER_SIZE = 2048;
-}
-
 bool Request::recvRequest() {
-    char buffer[BUFFER_SIZE];
+    char buffer[core::IO_BUFFER_SIZE];
 
-    int bytesReceived = recv(_client->getFd(), buffer, sizeof(buffer) - 1, 0);
+    int bytesReceived = recv(_client->getFd(), buffer, core::IO_BUFFER_SIZE, 0);
     if (bytesReceived == 0) {
         toolbox::logger::StepMark::info("Request: recvRequest: client "
             "disconnected " + toolbox::to_string(_client->getFd()));

--- a/src/http/response/response.cpp
+++ b/src/http/response/response.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <utility>
 
+#include "../../core/constant.hpp"
 #include "../../../toolbox/stepmark.hpp"
 
 namespace http {
@@ -62,7 +63,7 @@ void Response::sendResponse(int client_fd) const {
 
     while (total_sent < to_send) {
         ssize_t sent = send(client_fd, data + total_sent,
-            to_send - total_sent, 0);
+            to_send - total_sent, 0); // TODO: change to non-blocking send later
         if (sent <= 0) {
             std::ostringstream oss;
             oss << "Failed to send response:\n";

--- a/toolbox/access.cpp
+++ b/toolbox/access.cpp
@@ -20,6 +20,10 @@ The class is not thread-safe, so it should not be used in a multi-threaded envir
 #include <stdexcept>
 #include <string>
 
+namespace {
+    const std::size_t IO_BUFFER_SIZE = 16 * 1024; // 16 KB
+}
+
 namespace toolbox {
 
 /*

--- a/toolbox/stepmark.cpp
+++ b/toolbox/stepmark.cpp
@@ -20,6 +20,10 @@ The class is not thread-safe, so it should not be used in a multi-threaded envir
 #include <stdexcept>
 #include <string>
 
+namespace {
+    const std::size_t IO_BUFFER_SIZE = 16 * 1024; // 16 KB
+}
+
 namespace toolbox {
 
 /*


### PR DESCRIPTION
## 概要

## 変更内容

* IO_BUFFER_SIZEとして16kBを設定した
* recvの部分を書き換えた

## 関連Issue

* #142 

## 影響範囲

* 設定ファイル読み込み以外のI/O全般

## テスト

* test/http/request_parseがこれまで通り動くことを確認

## その他

* recv以外のI/O操作(read/write/send/operator<</operator>>)は今後のissueで書き換え予定です

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。
