### PR TITLE
112 requestクラスのレスポンスを返す関数を実装する

### DIFF
--- a/src/http/http_namespace.cpp
+++ b/src/http/http_namespace.cpp
@@ -35,6 +35,7 @@ const char* ACCEPT_ENCODING = "Accept-Encoding";
 const char* AUTHORIZATION = "Authorization";
 const char* USER_AGENT = "User-Agent";
 const char* COOKIE = "Cookie";
+const char* REFERER = "Referer";
 // response fields
 const char* SERVER = "Server";
 const char* SET_COOKIE = "Set-Cookie";
@@ -45,8 +46,9 @@ const char* FIELDS[] = {
 DATE,          CACHE_CONTROL,    CONNECTION,       CONTENT_LENGTH,
 CONTENT_TYPE,  CONTENT_ENCODING, CONTENT_LANGUAGE, TRANSFER_ENCODING,
 HOST,          ACCEPT,           ACCEPT_ENCODING,  ACCEPT_LANGUAGE,
-AUTHORIZATION, USER_AGENT,       COOKIE,           SERVER,
-SET_COOKIE,    LOCATION,         WWW_AUTHENTICATE, LAST_MODIFIED
+AUTHORIZATION, USER_AGENT,       COOKIE,           REFERER,
+SERVER,        SET_COOKIE,       LOCATION,         WWW_AUTHENTICATE,
+LAST_MODIFIED
 };
 const std::size_t FIELD_SIZE = sizeof(FIELDS) / sizeof(FIELDS[0]);
 const std::size_t MAX_FIELDLINE_SIZE = 8192;

--- a/src/http/http_namespace.hpp
+++ b/src/http/http_namespace.hpp
@@ -38,6 +38,7 @@ extern const char* ACCEPT_ENCODING;
 extern const char* AUTHORIZATION;
 extern const char* USER_AGENT;
 extern const char* COOKIE;
+extern const char* REFERER;
 // response fields
 extern const char* SERVER;
 extern const char* SET_COOKIE;

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -48,7 +48,7 @@ class Request {
     /**
      * @brief Sends the prepared HTTP response to the client.
      */
-    void sendResponse() const;
+    void sendResponse();
 
  private:
     http::RequestParser _parsedRequest;

--- a/src/http/request/request_impl_response.cpp
+++ b/src/http/request/request_impl_response.cpp
@@ -15,20 +15,56 @@ namespace {
         }
         return "-";
     }
-
 }
 
 void http::Request::sendResponse() {
-    int status = _response.getStatus();
+    std::size_t status = _response.getStatus();
+
+    if (status >= config::directive::MIN_ERROR_PAGE_CODE
+            && status <= config::directive::MAX_ERROR_PAGE_CODE) {
+        std::vector<config::ErrorPage> errorPages = _config.getErrorPages();
+        for (std::size_t i = 0; i < errorPages.size(); ++i) {
+            if (std::find(errorPages[i].getCodes().begin(),
+                    errorPages[i].getCodes().end(), status)
+                != errorPages[i].getCodes().end()) {
+                http::Request errorRequest(_client, _requestDepth + 1);
+                std::string method = http::method::GET;
+                std::string path = errorPages[i].getPath();
+                std::string host;
+                if (_parsedRequest.get().fields.getFieldValue(
+                        http::fields::HOST).empty()) {
+                    host = _client->getServerIp();
+                } else {
+                    host = _parsedRequest.get().fields.getFieldValue(
+                        http::fields::HOST)[0];
+                }
+                errorRequest.setLocalRedirectInfo(method, path, host);
+                errorRequest.fetchConfig();
+                errorRequest.handleRequest();
+                if (errorRequest._response.getStatus() == http::HttpStatus::OK) {
+                    // content-type も設定する必要あり
+                    _response.setBody(errorRequest._response.getBody());
+                } else {
+                    // _response.setHeader(http::fields::CONTENT_TYPE,
+                    //     "text/html");
+                    // _response.setBody("<html><body>"
+                    //     "<h1>Error: " + std::to_string(status) + "</h1>"
+                    //     "<p>Internal error occurred.</p></body></html>");
+                }
+            }
+        }
+    } 
+
+
 
     std::string remote_addr = _client->getIp();
     std::string remote_user = "-";
     std::string request = _parsedRequest.get().originalRequestLine;
     std::size_t body_bytes_sent = _response.getContentLength();
     std::string http_referer = getFieldValue(
-        _parsedRequest.get(), "Referer");
+        _parsedRequest.get(), http::fields::REFERER);
     std::string http_user_agent = getFieldValue(
-        _parsedRequest.get(), "User-Agent");
+        _parsedRequest.get(), http::fields::USER_AGENT);
 
     toolbox::logger::AccessLog::log(
         remote_addr,

--- a/src/http/request/request_impl_response.cpp
+++ b/src/http/request/request_impl_response.cpp
@@ -1,1 +1,43 @@
 #include "request.hpp"
+
+#include <string>
+#include <vector>
+
+#include "../../../toolbox/access.hpp"
+#include "../../../toolbox/string.hpp"
+
+namespace {
+    std::string getFieldValue(
+        http::HTTPRequest& request, const std::string& fieldName) {
+        std::vector<std::string> values = request.fields.getFieldValue(fieldName);
+        if (!values.empty()) {
+            return values[0];
+        }
+        return "-";
+    }
+
+}
+
+void http::Request::sendResponse() {
+    int status = _response.getStatus();
+
+    std::string remote_addr = _client->getIp();
+    std::string remote_user = "-";
+    std::string request = _parsedRequest.get().originalRequestLine;
+    std::size_t body_bytes_sent = _response.getContentLength();
+    std::string http_referer = getFieldValue(
+        _parsedRequest.get(), "Referer");
+    std::string http_user_agent = getFieldValue(
+        _parsedRequest.get(), "User-Agent");
+
+    toolbox::logger::AccessLog::log(
+        remote_addr,
+        remote_user,
+        request,
+        status,
+        body_bytes_sent,
+        http_referer,
+        http_user_agent
+    );
+    _response.sendResponse(_client->getFd());
+}

--- a/src/http/request/request_impl_response.cpp
+++ b/src/http/request/request_impl_response.cpp
@@ -15,6 +15,54 @@ namespace {
         }
         return "-";
     }
+
+    void propagateErrorPage(
+        http::Response* response, const http::Response& errorResponse) {
+        typedef std::string FieldName;
+        typedef std::string FieldDefaultValue;
+
+        // [TODO] ここも後で確認します
+        const std::pair<std::string, std::string> defaultHeadersArray[] = {
+            {http::fields::CONTENT_TYPE, "text/plain"},
+            {http::fields::CACHE_CONTROL, "no-cache"},
+            {http::fields::CONNECTION, "close"},
+            {http::fields::SERVER, "WebServer/1.0"}
+        };
+        const std::vector<std::pair<FieldName, FieldDefaultValue> > defaultHeaders(
+            defaultHeadersArray, defaultHeadersArray + sizeof(defaultHeadersArray)
+            / sizeof(defaultHeadersArray[0]));
+
+        for (std::size_t i = 0; i < defaultHeaders.size(); ++i) {
+            const std::pair<FieldName, FieldDefaultValue>& header =
+                defaultHeaders[i];
+            std::string headerValue = errorResponse.getHeader(header.first);
+            if (headerValue.empty()) {
+                headerValue = header.second;
+            }
+            response->setHeader(header.first, headerValue);
+        }
+        response->setBody(errorResponse.getBody());
+    }
+
+    void setDefaultErrorPage(http::Response* response, std::size_t status) {
+        // [TODO] 設定すべきフィールドを確認する
+        // [TODO] デフォルトのエラーページを設定する
+        response->setHeader(http::fields::CONTENT_TYPE, "text/html");
+        response->setStatus(status);
+        std::stringstream ss;
+        ss << "<!DOCTYPE html>\n"
+            << "<html>\n"
+            << "<head>\n"
+            << "<title>Error " << status << "</title>\n"
+            << "</head>\n"
+            << "<body>\n"
+            << "<h1>Error " << status << "</h1>\n"
+            << "<p>An error occurred while processing your request.</p>\n"
+            << "</body>\n"
+            << "</html>";
+        response->setBody(ss.str());
+    }
+
 }
 
 void http::Request::sendResponse() {
@@ -23,10 +71,19 @@ void http::Request::sendResponse() {
     if (status >= config::directive::MIN_ERROR_PAGE_CODE
             && status <= config::directive::MAX_ERROR_PAGE_CODE) {
         std::vector<config::ErrorPage> errorPages = _config.getErrorPages();
+        bool useDefaultErrorPage = true;
         for (std::size_t i = 0; i < errorPages.size(); ++i) {
             if (std::find(errorPages[i].getCodes().begin(),
                     errorPages[i].getCodes().end(), status)
                 != errorPages[i].getCodes().end()) {
+                // [TODO] Change the processing of the error page
+                // depending on the prefix of the error page path
+                // "/" - ngx_http_internal_redirect
+                // "@" - ngx_http_named_location
+                // otherwise - ngx_http_send_refresh or ngx_http_send_special_response
+
+                // [TODO] この辺は後で書きます
+
                 http::Request errorRequest(_client, _requestDepth + 1);
                 std::string method = http::method::GET;
                 std::string path = errorPages[i].getPath();
@@ -42,20 +99,15 @@ void http::Request::sendResponse() {
                 errorRequest.fetchConfig();
                 errorRequest.handleRequest();
                 if (errorRequest._response.getStatus() == http::HttpStatus::OK) {
-                    // content-type も設定する必要あり
-                    _response.setBody(errorRequest._response.getBody());
-                } else {
-                    // _response.setHeader(http::fields::CONTENT_TYPE,
-                    //     "text/html");
-                    // _response.setBody("<html><body>"
-                    //     "<h1>Error: " + std::to_string(status) + "</h1>"
-                    //     "<p>Internal error occurred.</p></body></html>");
+                    propagateErrorPage(&_response, errorRequest._response);
+                    useDefaultErrorPage = false;
                 }
             }
         }
+        if (useDefaultErrorPage) {
+            setDefaultErrorPage(&_response, status);
+        }
     } 
-
-
 
     std::string remote_addr = _client->getIp();
     std::string remote_user = "-";

--- a/src/http/response/response.cpp
+++ b/src/http/response/response.cpp
@@ -150,6 +150,14 @@ int Response::getStatus() const {
     return _status;
 }
 
+std::string Response::getHeader(const FieldName& name) const {
+    std::map<FieldName, HeaderField>::const_iterator it = _headers.find(name);
+    if (it != _headers.end() && it->second.first) {
+        return it->second.second;
+    }
+    return "";  // Return empty string if header not found or disabled
+}
+
 std::size_t Response::getContentLength() const {
     return _body.size();
 }

--- a/src/http/response/response.hpp
+++ b/src/http/response/response.hpp
@@ -37,6 +37,8 @@ class Response {
 
     int getStatus() const;
 
+    std::string getHeader(const FieldName& name) const;
+
     std::size_t getContentLength() const;
 
     std::string getBody() const;


### PR DESCRIPTION
## 概要

Request::sendResponseの大枠を実装した

## 変更内容

* Request::sendResponseのError Pageの周りがちょっと複雑そうだったため、一旦issueを分けることにした

* 実装した部分
  * AccessLogに記録する部分
  * レスポンスを送る部分(今はまだblocking)
  * エラーページを探す部分、なかった場合にデフォルトのエラーページを設定する部分
  * エラーページ作成用のRequestインスタンスを作る流れのイメージ
* 残っているタスク
  * statusのoverwriteについて→設定ファイルで未対応らしい。優先度は低そうなので対応なしでもいい気がする
  * error_pageのパスのprefixによる分類 (以下はnginxで処理する関数名)
    * `/` - `ngx_http_internal_redirect`
    * `@` - `ngx_http_named_location`
    * otherwise - `ngx_http_send_refresh` or `ngx_http_send_special_response`
  * error page作成用に使ったRequestインスタンスから元のRequestインスタンスのResponseに反映させるべきフィールドを確認する
  * Content-Type, Content-Length(ResponseクラスでBodyから計算されるため設定不要), Cache-Control, Server, Expires, Pragmaあたり？
  * デフォルトのエラーページについて、設定すべきフィールドを確認する
  * デフォルトのエラーページについて、Bodyを決める（今のままでもいい）
  * non-blockingにする

## 関連Issue

* #112 
* #153
  * 残りのToDoはここに移しました
* #81 は、Request::sendResponseの中でAccessLogを呼ぶことにしたので、閉じます

## 影響範囲

* Request::sendResponse

## テスト

* 未完成なのでテストなしです。 #153 と一緒にテストします

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | HTTPヘッダーフィールドに`REFERER`が追加され、`FIELDS`配列とそのサイズが更新されました。 |
| New Feature | `Response`クラスに新しいメソッド`getHeader`が追加され、ヘッダー値を取得できるようになりました。 |
| Refactor | `Request`クラスの`sendResponse`メソッドから`const`修飾子が削除され、オブジェクトの状態を変更可能になりました。 |

このプルリクエストでは、HTTPプロトコルの機能拡張とコードの柔軟性向上が図られており、特に`REFERER`フィールドの追加はユーザー体験の向上に寄与しています。素晴らしい改善です！
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->