### PR TITLE
145 requestクラスで途中の処理の状態を持つようにする

### DIFF
--- a/src/http/request/handleRequest.cpp
+++ b/src/http/request/handleRequest.cpp
@@ -8,6 +8,13 @@
 
 namespace http {
 void Request::handleRequest() {
+    if (_response.getStatus() != 200) {
+        toolbox::logger::StepMark::error(
+            "Request::handleRequest: Response already set status "
+                + std::to_string(_response.getStatus()) + " does not handle request");
+        return;
+    }
+
     HTTPRequest& httpRequest = _parsedRequest.get();
     const std::vector<std::string>& allowedMethods = _config.getAllowedMethods();
 
@@ -27,8 +34,19 @@ void Request::handleRequest() {
     const std::vector<std::string>& cgiExtensionVector = _config.getCgiExtensions();
 
     if (cgiHandler.isCgiRequest(targetPath, cgiExtensionVector, cgiPath)) {
+        
         cgiHandler.handleRequest(httpRequest, _response,
             _config.getRoot(), cgiExtensionVector, cgiPath);
+        
+
+/*
+            //ここでCGIの種類が帰ってくる。
+            DOCUMENT = 0,
+            LOCAL_REDIRECT = 1,
+            CLIENT_REDIRECT = 2,
+            CLIENT_REDIRECT_DOCUMENT = 3,
+            INVALID = 4
+*/
     } else {
         serverMethod::serverMethodHandler(
             _parsedRequest, _config, httpRequest.fields, _response);

--- a/src/http/request/handleRequest.cpp
+++ b/src/http/request/handleRequest.cpp
@@ -21,6 +21,7 @@ void Request::handleRequest() {
     if (std::find(allowedMethods.begin(), allowedMethods.end(),
                     httpRequest.method) == allowedMethods.end()) {
         _response.setStatus(HttpStatus::METHOD_NOT_ALLOWED);
+        _ioPendingState = IOPendingState::NO_IO_PENDING;
         toolbox::logger::StepMark::error(
             "Request::handleRequest: Method not allowed: "
                 + httpRequest.method);
@@ -34,19 +35,8 @@ void Request::handleRequest() {
     const std::vector<std::string>& cgiExtensionVector = _config.getCgiExtensions();
 
     if (cgiHandler.isCgiRequest(targetPath, cgiExtensionVector, cgiPath)) {
-        
-        cgiHandler.handleRequest(httpRequest, _response,
+        _ioPendingState = cgiHandler.handleRequest(httpRequest, _response,
             _config.getRoot(), cgiExtensionVector, cgiPath);
-        
-
-/*
-            //ここでCGIの種類が帰ってくる。
-            DOCUMENT = 0,
-            LOCAL_REDIRECT = 1,
-            CLIENT_REDIRECT = 2,
-            CLIENT_REDIRECT_DOCUMENT = 3,
-            INVALID = 4
-*/
     } else {
         serverMethod::serverMethodHandler(
             _parsedRequest, _config, httpRequest.fields, _response);

--- a/src/http/request/recv_request.cpp
+++ b/src/http/request/recv_request.cpp
@@ -102,7 +102,7 @@ bool Request::isValidBodySize() {
 
 bool Request::recvRequest() {
     std::string receivedData;
-    
+
     if (!performRecv(receivedData)) {
         _ioPendingState = IOPendingState::NO_IO_PENDING;
         toolbox::logger::StepMark::error("Request: recvRequest: failed to receive data");

--- a/src/http/request/recv_request.cpp
+++ b/src/http/request/recv_request.cpp
@@ -119,10 +119,10 @@ bool Request::recvRequest() {
     }
 
     if (!isValidBodySize()) {
-        toolbox::logger::StepMark::error("Request: recvRequest: request have "
-            "invalid body/content size");
         _response.setStatus(HttpStatus::PAYLOAD_TOO_LARGE);
         _ioPendingState = IOPendingState::NO_IO_PENDING;
+        toolbox::logger::StepMark::error("Request: recvRequest: request have "
+            "invalid body/content size");
         return false;
     }
 

--- a/src/http/request/request.cpp
+++ b/src/http/request/request.cpp
@@ -1,0 +1,29 @@
+#include "request.hpp"
+
+namespace http {
+void Request::run() {
+  switch (_ioPendingState) {
+    case NO_IO_PENDING:
+    case REQUEST_READING:
+        recvRequest();
+        if (_ioPendingState != NO_IO_PENDING)
+            break;
+    // [[fallthrough]]
+    case CGI_BODY_SENDING:
+    case CGI_OUTPUT_READING:
+    case CGI_LOCAL_REDIRECT_IO_PENDING:
+        handleRequest();
+        if (_ioPendingState != NO_IO_PENDING)
+            break;
+    // [[fallthrough]]
+    case ERROR_LOCAL_REDIRECT_IO_PENDING:
+    case RESPONSE_SENDING:
+        sendResponse();
+        break;
+    default:
+        // never come here
+        break;
+  }
+}
+
+}  // namespace http

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -15,8 +15,8 @@ enum IOPendingState {
   REQUEST_READING,
   CGI_BODY_SENDING,
   CGI_OUTPUT_READING,
-  CGI_LOCAL_REDIRECT_IO_PENDING, // Local RedirectのRequestの処理から帰ってきた時に、子RequestクラスのioPendingStateがNO_IO_PENDING以外になっていたらセットされる
-  ERROR_LOCAL_REDIRECT_IO_PENDING, // Local RedirectのRequestの処理から帰ってきた時に、子RequestクラスのioPendingStateがNO_IO_PENDING以外になっていたらセットされる
+  CGI_LOCAL_REDIRECT_IO_PENDING,
+  ERROR_LOCAL_REDIRECT_IO_PENDING,
   RESPONSE_SENDING,
   NO_IO_PENDING
 };

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -11,6 +11,16 @@
 
 namespace http {
 
+enum IOPendingState {
+  REQUEST_READING,
+  CGI_BODY_SENDING,
+  CGI_OUTPUT_READING,
+  CGI_LOCAL_REDIRECT_IO_PENDING, // Local RedirectのRequestの処理から帰ってきた時に、子RequestクラスのioPendingStateがNO_IO_PENDING以外になっていたらセットされる
+  ERROR_LOCAL_REDIRECT_IO_PENDING, // Local RedirectのRequestの処理から帰ってきた時に、子RequestクラスのioPendingStateがNO_IO_PENDING以外になっていたらセットされる
+  RESPONSE_SENDING,
+  NO_IO_PENDING
+};
+
 class Request {
  public:
     /**
@@ -25,6 +35,12 @@ class Request {
      * @brief Destructor for the Request object.
      */
     ~Request();
+
+    /**
+     * @brief Runs the request processing, including receiving the request,
+     * fetching configuration, handling the request, and sending the response.
+     */
+    void run();
 
     /**
      * @brief recieve and parses the raw HTTP request string.
@@ -59,6 +75,7 @@ class Request {
     http::Response _response;
     toolbox::SharedPtr<Client> _client;
     std::size_t _requestDepth;
+    IOPendingState _ioPendingState;
 
     Request();
     Request(const Request& other);

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -30,7 +30,7 @@ class Request {
      * associated with this request.
      */
     Request(const toolbox::SharedPtr<Client>& client, std::size_t requestDepth = 0)
-        : _ioPendingState(REQUEST_READING) {};
+        : _ioPendingState(REQUEST_READING) {}
 
     /**
      * @brief Destructor for the Request object.

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -29,7 +29,8 @@ class Request {
      * @param requestDepth The depth of the request, used to track local redirects
      * associated with this request.
      */
-    Request(const toolbox::SharedPtr<Client>& client, std::size_t requestDepth = 0);
+    Request(const toolbox::SharedPtr<Client>& client, std::size_t requestDepth = 0)
+        : _ioPendingState(REQUEST_READING) {};
 
     /**
      * @brief Destructor for the Request object.
@@ -84,7 +85,7 @@ class Request {
     // recvRequest helper methods
     bool performRecv(std::string& receivedData);
     bool loadConfig();
-    bool validateBodySize();
+    bool isValidBodySize();
     // fetchConfig helper methods
     toolbox::SharedPtr<config::ServerConfig> selectServer();
     bool extractCandidateServers(

--- a/src/http/response/method_get.cpp
+++ b/src/http/response/method_get.cpp
@@ -148,7 +148,6 @@ void runGet(const std::string& path, std::vector<std::string>& indices,
         } else {
             throw HttpStatus::INTERNAL_SERVER_ERROR;
         }
-        response.setStatus(HttpStatus::OK);
     } catch (const HttpStatus::EHttpStatus& e) {
         toolbox::logger::StepMark::error("runGet: set status "
             + toolbox::to_string(e));


### PR DESCRIPTION
## 概要
145 requestクラスで途中の処理の状態を持つようにする
## 変更内容

* src/http/request/request.c/hpp
request.hppにenum、メンバ変数に_ioPendingStateを作成し、コンストラクタでREQUEST _READINGに設定
request.cppにrun()を用意(discordそのまま)

* recv_request.cpp内部でioPendingStateを更新する処理を追加
エラー発生時に_request.statusを変更しNO_IO_PENDINGを設定

* src/http/request/handleRequest.cpp
この関数以前で_request.statusが設定されていた場合logを出力し、returnする。
CGIの場合はpipeでの入出力が存在するためIOPendingStateを戻り値としその値を設定する。
serverMethodの場合はepollに追加するfdが存在しない(現状は、今後その存在に気付いた場合は変更の必要有)ため、_ioPendingStateは変更しない

## 関連Issue

* #100 
* #91 

## 影響範囲

* src/http/request

## テスト

* 特になし、動かしてみないとわからない

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | `Request`クラスにI/O状態管理が追加され、リクエスト処理のロジックが改善されました。 |
| Bug fix | エラーハンドリングが強化され、許可されていないHTTPメソッドの処理が追加されました。 |
| Refactor | メソッド名が`validateBodySize`から`isValidBodySize`に変更され、一貫性が向上しました。 |

このプルリクエストでは、コードのモジュール性と保守性が大幅に向上しており、特にI/O状態管理の導入によってリクエスト処理の効率が高まっています。エラーハンドリングの強化も素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->