### PR TITLE
166 httpiopendingstateを専用のファイルに移す

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -19,6 +19,7 @@
 #include "../../toolbox/string.hpp"
 #include "../../toolbox/shared.hpp"
 #include "../http/request/request.hpp"
+#include "../http/request/io_pending_state.hpp"
 
 int main(int argc, char* argv[]) {
     try {

--- a/src/http/request/handleRequest.cpp
+++ b/src/http/request/handleRequest.cpp
@@ -5,6 +5,7 @@
 #include "../cgi/cgi_handler.hpp"
 #include "request.hpp"
 #include "../response/server_method_handler.hpp"
+#include "io_pending_state.hpp"
 
 namespace http {
 void Request::handleRequest() {

--- a/src/http/request/io_pending_state.hpp
+++ b/src/http/request/io_pending_state.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace http {
+enum IOPendingState {
+    REQUEST_READING,
+    CGI_BODY_SENDING,
+    CGI_OUTPUT_READING,
+    CGI_LOCAL_REDIRECT_IO_PENDING,
+    ERROR_LOCAL_REDIRECT_IO_PENDING,
+    RESPONSE_SENDING,
+    NO_IO_PENDING
+};
+}  // namespace http

--- a/src/http/request/recv_request.cpp
+++ b/src/http/request/recv_request.cpp
@@ -6,6 +6,7 @@
 #include "../../core/constant.hpp"
 #include "request_parser.hpp"
 #include "request.hpp"
+#include "io_pending_state.hpp"
 
 namespace http {
 namespace {

--- a/src/http/request/request.cpp
+++ b/src/http/request/request.cpp
@@ -1,4 +1,5 @@
 #include "request.hpp"
+#include "io_pending_state.hpp"
 
 namespace http {
 void Request::run() {

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -7,20 +7,11 @@
 #include "../response/response.hpp"
 #include "../../config/config.hpp"
 #include "../../../toolbox/shared.hpp"
+#include "io_pending_state.hpp"
 
 class Client;
 
 namespace http {
-
-enum IOPendingState {
-  REQUEST_READING,
-  CGI_BODY_SENDING,
-  CGI_OUTPUT_READING,
-  CGI_LOCAL_REDIRECT_IO_PENDING,
-  ERROR_LOCAL_REDIRECT_IO_PENDING,
-  RESPONSE_SENDING,
-  NO_IO_PENDING
-};
 
 class Request {
  public:

--- a/src/http/request/request_impl_basic.cpp
+++ b/src/http/request/request_impl_basic.cpp
@@ -4,6 +4,7 @@
 #include "../../core/client.hpp"
 #include "../../../toolbox/shared.hpp"
 #include "request_parser.hpp"
+#include "io_pending_state.hpp"
 
 http::Request::Request(const toolbox::SharedPtr<Client>& client, std::size_t requestDepth)
     : _client(client), _requestDepth(requestDepth), _ioPendingState(REQUEST_READING) {


### PR DESCRIPTION
## 概要
httpiopendingstateを専用のファイルに移す

## 変更内容

現在はrequest.hppにhttp::IOPendingStateが入っている。
request.hppからcgi_handler.hppを参照するため、cgi_handler.hppからhttp::IOPendingStateにアクセスできない状況になっているため、http::IOPendingStateをio_pending_state.hppに移すことでこれを解決する

## 関連Issue

* #166 

## 影響範囲

* http::Requestクラス（特にnon-blockingに関わるところ）
* 挙動自体は変わらないはず

## テスト

* 既存の種々のテストが動けばOK
* 挙動自体は変わっていないはずなので多分コンパイルを確認するだけでOKです

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。
