### PR TITLE
fix: curl request bug

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -79,7 +79,17 @@ int main(int argc, char* argv[]) {
                             int client_sock = client->getFd();
                             std::cout << "send response to client fd: " << client_sock << std::endl;
 
-                            client->getRequest()->run();
+                            if (events[i].events & EPOLLRDHUP) {
+                                Epoll::del(client_sock);
+                                continue;
+                            } else if (events[i].events & EPOLLIN) {
+                                client->getRequest()->run();
+                            } else {
+                                toolbox::logger::StepMark::error("Epoll: unknown event for client fd: " + toolbox::to_string(client_sock));
+                                Epoll::del(client_sock);
+                                continue;
+                            }
+
                             // if (!client->getRequest()->isKeepAliveRequest() &&
                             //     client->getRequest()->getIOPendingState() == http::NO_IO_PENDING) {
                             Epoll::del(client_sock);

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -90,10 +90,10 @@ int main(int argc, char* argv[]) {
                                 continue;
                             }
 
-                            // if (!client->getRequest()->isKeepAliveRequest() &&
-                            //     client->getRequest()->getIOPendingState() == http::NO_IO_PENDING) {
+                            if (!client->getRequest()->isKeepAliveRequest() &&
+                                client->getRequest()->getIOPendingState() == http::NO_IO_PENDING) {
                             Epoll::del(client_sock);
-                            // }
+                            }
                         } catch (std::exception& e) {
                             std::cerr << e.what() << std:: endl;
                         }

--- a/src/event/epoll.cpp
+++ b/src/event/epoll.cpp
@@ -51,7 +51,7 @@ void Epoll::addServer(int fd, toolbox::SharedPtr<Server> server) {
 void Epoll::addClient(int fd, toolbox::SharedPtr<Client> client) {
     Epoll& epollInstance = getInstance();
     struct epoll_event* ev = new struct epoll_event;
-    ev->events = EPOLLIN;
+    ev->events = EPOLLIN | EPOLLRDHUP;
     taggedEventData* tagged = new taggedEventData;
     tagged->client = client;
     ev->data.ptr = static_cast<void*>(tagged);


### PR DESCRIPTION
~

## 概要

curl, telnetで発生していたバグ修正

## 変更内容

* curl
  * リクエストを送信した後にサーバーが異常終了する
    * epollの監視イベントにEPOLLRDHUP(どちらかのソケットが閉じられたことを検知する)を追加
    * curlコマンドの終了を検知した場合対象のepollをdeleteする
    * 他ブラウザで発生した問題がこれで解決するかは分かりません。試していただけると助かります。
* telnet
  * リクエストが複数回になるので毎回epollをdelしていた部分に条件文を追加し、正しくリクエストを送信できるように変更
  * 改行を送り続けると同じレスポンスが帰ってきますが、今後の #156 で解決する予定です。
  * IOPendingStateにEND_RESPONSEが追加された場合epoll delのif文の部分を #156 で修正予定です

## 関連Issue


## 影響範囲

* 

## テスト

* サーバーを立てcurl, telnetまたその他ブラウザで正しく動作しなかったものについてテストお願いします。

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | `epoll`の監視イベントに`EPOLLRDHUP`を追加し、ソケットの閉鎖を検知して適切に処理する機能が追加されました。 |
| Bug fix | 未知の`epoll`イベント発生時にエラーをログに記録し、`epoll`から削除することでサーバーの安定性が向上しました。 |

このプルリクエストでは、サーバーの異常終了を防ぐためのロジックが強化されており、特に`EPOLLRDHUP`の追加によって接続管理がより堅牢になっています。コードの保守性と信頼性が大幅に向上している点が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->