### PR TITLE
173 end_responseを追加する

### DIFF
--- a/src/http/request/io_pending_state.hpp
+++ b/src/http/request/io_pending_state.hpp
@@ -8,6 +8,7 @@ enum IOPendingState {
     CGI_LOCAL_REDIRECT_IO_PENDING,
     ERROR_LOCAL_REDIRECT_IO_PENDING,
     RESPONSE_SENDING,
-    NO_IO_PENDING
+    NO_IO_PENDING,
+    END_RESPONSE
 };
 }  // namespace http


### PR DESCRIPTION
## 概要

end_responseを追加する

## 変更内容

* END_RESPONSEをIOPendingStateに追加しました

## 関連Issue

* #173 

## 影響範囲

* IOPendingState

## テスト

* 特になし

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | `IOPendingState`列挙型に新しい状態`END_RESPONSE`が追加され、HTTPリクエスト処理の状態管理が強化されました。 |

このプルリクエストでは、HTTPリクエストの状態管理をより詳細に行えるようにするための重要な改善が行われています。コードの拡張性と保守性を考慮した設計が素晴らしく、今後の機能追加にも柔軟に対応できる基盤が整っています。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->