### PR TITLE
181 _requestDepth=0以外のとき、recvRequestしない

### DIFF
--- a/src/http/request/request.cpp
+++ b/src/http/request/request.cpp
@@ -22,7 +22,9 @@ void Request::run() {
         // fallthrough
         case ERROR_LOCAL_REDIRECT_IO_PENDING:
         case RESPONSE_SENDING:
-            Request::sendResponse();
+            if (_requestDepth == root_depth) {
+                Request::sendResponse();
+            }
             break;
         default:
             // never come here

--- a/src/http/request/request.cpp
+++ b/src/http/request/request.cpp
@@ -6,9 +6,11 @@ void Request::run() {
   switch (_ioPendingState) {
     case NO_IO_PENDING:
     case REQUEST_READING:
-        recvRequest();
-        if (_ioPendingState != NO_IO_PENDING)
-            break;
+        if (_requestDepth == 0) {
+            recvRequest();
+            if (_ioPendingState != NO_IO_PENDING)
+                break;
+        }
     // fallthrough
     case CGI_BODY_SENDING:
     case CGI_OUTPUT_READING:

--- a/src/http/request/request.cpp
+++ b/src/http/request/request.cpp
@@ -3,10 +3,11 @@
 
 namespace http {
 void Request::run() {
-  switch (_ioPendingState) {
+    const std::size_t root_depth = 0;
+    switch (_ioPendingState) {
     case NO_IO_PENDING:
     case REQUEST_READING:
-        if (_requestDepth == 0) {
+        if (_requestDepth == root_depth) {
             recvRequest();
             if (_ioPendingState != NO_IO_PENDING)
                 break;

--- a/src/http/request/request.cpp
+++ b/src/http/request/request.cpp
@@ -5,29 +5,29 @@ namespace http {
 void Request::run() {
     const std::size_t root_depth = 0;
     switch (_ioPendingState) {
-    case NO_IO_PENDING:
-    case REQUEST_READING:
-        if (_requestDepth == root_depth) {
-            recvRequest();
+        case NO_IO_PENDING:
+        case REQUEST_READING:
+            if (_requestDepth == root_depth) {
+                recvRequest();
+                if (_ioPendingState != NO_IO_PENDING)
+                    break;
+            }
+        // fallthrough
+        case CGI_BODY_SENDING:
+        case CGI_OUTPUT_READING:
+        case CGI_LOCAL_REDIRECT_IO_PENDING:
+            handleRequest();
             if (_ioPendingState != NO_IO_PENDING)
                 break;
-        }
-    // fallthrough
-    case CGI_BODY_SENDING:
-    case CGI_OUTPUT_READING:
-    case CGI_LOCAL_REDIRECT_IO_PENDING:
-        handleRequest();
-        if (_ioPendingState != NO_IO_PENDING)
+        // fallthrough
+        case ERROR_LOCAL_REDIRECT_IO_PENDING:
+        case RESPONSE_SENDING:
+            Request::sendResponse();
             break;
-    // fallthrough
-    case ERROR_LOCAL_REDIRECT_IO_PENDING:
-    case RESPONSE_SENDING:
-        Request::sendResponse();
-        break;
-    default:
-        // never come here
-        break;
-  }
+        default:
+            // never come here
+            break;
+    }
 }
 
 }  // namespace http


### PR DESCRIPTION
## 概要

_requestDepth=0以外のとき、recvRequestしないし、sendResponseしない

## 変更内容

* _requestDepth=0以外のとき、recvRequestやsendResponseしないように変更する
これにより、 _requestDepthが1以上、すなわち、local redirectやerror pageの処理の場合でも、元のrecvが必要なリクエストと同様にrequest.runするだけで適切に実行されるようになる

## 関連Issue

* #181

## 影響範囲

* request処理全般

## テスト

* requestDepthが1以上である時のテストは、今後CGIやresponseのPRが出たときにやる
* requestDepthが0であるときのテストは、プロジェクト全体をmakeして実行後、アクセスできるかを調べる。（この際、405などが出なければ正しそう）

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。




<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Bug fix | `Request::run()`関数のロジックが修正され、リクエストの処理フローが適切に分岐するようになりました。これにより、ローカルリダイレクトやエラーページのシナリオでの問題が解決されました。 |

このプルリクエストでは、既存のコードベースを大きく変更せずに、重要なバグを効果的に修正しています。特に、条件分岐の改善によって、複雑なリクエスト処理がより直感的かつ効率的になった点が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->