### PR TITLE
fix: delete HTTP/1.0, body_max_size

### DIFF
--- a/src/http/http_namespace.cpp
+++ b/src/http/http_namespace.cpp
@@ -10,7 +10,6 @@ const char* DELETE = "DELETE";
 }  // namespace method
 
 namespace uri {
-const char* HTTP_VERSION_1_0 = "HTTP/1.0";
 const char* HTTP_VERSION_1_1 = "HTTP/1.1";
 const std::size_t HTTP_MAJOR_VERSION = 1;
 const std::size_t HTTP_MINOR_VERSION_MAX = 999;
@@ -52,7 +51,6 @@ LAST_MODIFIED
 };
 const std::size_t FIELD_SIZE = sizeof(FIELDS) / sizeof(FIELDS[0]);
 const std::size_t MAX_FIELDLINE_SIZE = 8192;
-const std::size_t MAX_BODY_SIZE = 1048576;
 namespace cgi {
 const char* STATUS = "Status";
 }

--- a/src/http/http_namespace.hpp
+++ b/src/http/http_namespace.hpp
@@ -14,7 +14,6 @@ extern const char* DELETE;
 
 namespace uri {
 extern const char* HTTP_VERSION_1_1;
-extern const char* HTTP_VERSION_1_0;
 extern const std::size_t HTTP_MAJOR_VERSION;
 extern const std::size_t HTTP_MINOR_VERSION_MAX;
 extern const std::size_t MAX_URI_SIZE;
@@ -48,7 +47,6 @@ extern const char* LAST_MODIFIED;
 extern const char* FIELDS[];
 extern const std::size_t FIELD_SIZE;
 extern const std::size_t MAX_FIELDLINE_SIZE;
-extern const std::size_t MAX_BODY_SIZE;
 namespace cgi {
 extern const char* STATUS;
 }  // namespace cgi

--- a/test/http/request_parse/requestline_testcase.cpp
+++ b/test/http/request_parse/requestline_testcase.cpp
@@ -510,16 +510,6 @@ void makeHttpVersionTests(TestVector& t) {
     t.push_back(r);
     clearUri(r);
 
-    r._name = "HTTP/1.0";  // 対応するかどうか決める
-    r._request = "GET / HTTP/1.0\r\nHost: sample\r\n\r\n";
-    r._httpStatus.set(http::HttpStatus::OK);
-    r._isSuccessTest = true;
-    r._exceptRequest.method = "GET";
-    r._exceptRequest.path = "/";
-    r._exceptRequest.version = "HTTP/1.0";
-    t.push_back(r);
-    clearUri(r);
-
     r._name = "不正なHTTPバージョン";
     r._request = "GET / HTTP/2.0\r\nHost: sample\r\n\r\n";
     r._httpStatus.set(http::HttpStatus::HTTP_VERSION_NOT_SUPPORTED);


### PR DESCRIPTION
~

## 概要

HTTP/1.0の対応をするために定義されていた定数を削除する

## 変更内容

* HTTP_VERSION_1_0
* MAX_BODY_SIZE
上記2つの削除

## 関連Issue

## 影響範囲

* src/http

## テスト

* 特になし

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | `HTTP_VERSION_1_0`と`MAX_BODY_SIZE`の定数が削除され、コードベースが簡素化されました。 |
| Test | HTTP/1.0に関連するテストケースが削除され、テストスイートが最新のサポート範囲に一致しました。 |

このプルリクエストでは、不要な定数とテストケースを整理し、コードの保守性と一貫性を向上させています。特に、古いプロトコルのサポートを見直すことで、将来の開発がより効率的になる点が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->