### PR TITLE
172 [response]レスポンスの送信をnon blockingにする

### DIFF
--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -95,6 +95,7 @@ class Request {
     toolbox::SharedPtr<Client> _client;
     std::size_t _requestDepth;
     IOPendingState _ioPendingState;
+    toolbox::SharedPtr<http::Request> _ErrorPageRequest;
 
     Request();
     Request(const Request& other);

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -95,7 +95,7 @@ class Request {
     toolbox::SharedPtr<Client> _client;
     std::size_t _requestDepth;
     IOPendingState _ioPendingState;
-    toolbox::SharedPtr<http::Request> _ErrorPageRequest;
+    toolbox::SharedPtr<http::Request> _errorPageRequest;
 
     Request();
     Request(const Request& other);

--- a/src/http/request/request_impl_response.cpp
+++ b/src/http/request/request_impl_response.cpp
@@ -80,68 +80,87 @@ void http::Request::sendResponse() {
         return;
     }
     std::size_t status = _response.getStatus();
-    if (_ioPendingState != http::RESPONSE_SENDING) {
+    if (_ioPendingState != http::RESPONSE_SENDING && 
+        status >= config::directive::MIN_ERROR_PAGE_CODE && 
+        status <= config::directive::MAX_ERROR_PAGE_CODE) {
         if (_ioPendingState != http::ERROR_LOCAL_REDIRECT_IO_PENDING) {
-            if (status >= config::directive::MIN_ERROR_PAGE_CODE
-                    && status <= config::directive::MAX_ERROR_PAGE_CODE) {
-                std::vector<config::ErrorPage> errorPages = _config.getErrorPages();
-                bool useDefaultErrorPage = true;
-                for (std::size_t i = 0; i < errorPages.size(); ++i) {
-                    if (std::find(errorPages[i].getCodes().begin(),
-                            errorPages[i].getCodes().end(), status)
-                        != errorPages[i].getCodes().end()) {
-                        // [TODO] Change the processing of the error page
-                        // depending on the prefix of the error page path
-                        // "/" - ngx_http_internal_redirect
-                        // "@" - ngx_http_named_location
-                        // otherwise - ngx_http_send_refresh or ngx_http_send_special_response
+            std::vector<config::ErrorPage> errorPages = _config.getErrorPages();
+            bool useDefaultErrorPage = true;
+            for (std::size_t i = 0; i < errorPages.size(); ++i) {
+                if (std::find(errorPages[i].getCodes().begin(),
+                        errorPages[i].getCodes().end(), status)
+                    != errorPages[i].getCodes().end()) {
+                    // [TODO] Change the processing of the error page
+                    // depending on the prefix of the error page path
+                    // "/" - ngx_http_internal_redirect
+                    // "@" - ngx_http_named_location
+                    // otherwise - ngx_http_send_refresh or ngx_http_send_special_response
 
-                        // [TODO] この辺は後で書きます
+                    // [TODO] この辺は後で書きます
 
-                        http::Request errorRequest(_client, _requestDepth + 1);
-                        std::string method = http::method::GET;
-                        std::string path = errorPages[i].getPath();
-                        std::string host;
-                        if (_parsedRequest.get().fields.getFieldValue(
-                                http::fields::HOST).empty()) {
-                            host = _client->getServerIp();
-                        } else {
-                            host = _parsedRequest.get().fields.getFieldValue(
-                                http::fields::HOST)[0];
-                        }
-                        // errorRequest.setLocalRedirectInfo(method, path, host);
-                        errorRequest.fetchConfig();
-                        errorRequest.handleRequest();
-                        if (errorRequest._response.getStatus() == http::HttpStatus::OK) {
-                            propagateErrorPage(&_response, errorRequest._response);
-                            useDefaultErrorPage = false;
-                        }
+                    _errorPageRequest = toolbox::SharedPtr<http::Request>(
+                        new http::Request(_client, _requestDepth + 1));
+                    std::string method = http::method::GET;
+                    std::string path = errorPages[i].getPath();
+                    std::string host;
+                    if (_parsedRequest.get().fields.getFieldValue(
+                            http::fields::HOST).empty()) {
+                        host = _client->getServerIp();
+                    } else {
+                        host = _parsedRequest.get().fields.getFieldValue(
+                            http::fields::HOST)[0];
                     }
+                    _errorPageRequest->setLocalRedirectInfo(method, path, host);
+                    _errorPageRequest->fetchConfig();
+                    useDefaultErrorPage = false;
+                    break;
                 }
-                if (useDefaultErrorPage) {
-                    setDefaultErrorPage(&_response, status);
-                }
+            }
+            if (useDefaultErrorPage) {
+                setDefaultErrorPage(&_response, status);
+            }
+        }
+        if (_errorPageRequest) {
+            _errorPageRequest->run();
+            if (_errorPageRequest->getIOPendingState() == http::CGI_BODY_SENDING
+                || _errorPageRequest->getIOPendingState() == http::CGI_OUTPUT_READING
+                || _errorPageRequest->getIOPendingState() == http::CGI_LOCAL_REDIRECT_IO_PENDING) {
+                _ioPendingState = http::ERROR_LOCAL_REDIRECT_IO_PENDING;
+                return;
+            }
+            int errorStatus = _errorPageRequest->getResponse().getStatus();
+            if (errorStatus >= 200 && errorStatus < 400) { // [TODO]:magic numberなので後で修正
+                propagateErrorPage(&_response, _errorPageRequest->getResponse());
+            } else {
+                setDefaultErrorPage(&_response, status);
             }
         }
     }
 
-    std::string remote_addr = _client->getIp();
-    std::string remote_user = "-";
-    std::string request = _parsedRequest.get().originalRequestLine;
-    std::size_t body_bytes_sent = _response.getContentLength();
-    std::string http_referer = getFieldValue(
-        _parsedRequest.get(), http::fields::REFERER);
-    std::string http_user_agent = getFieldValue(
-        _parsedRequest.get(), http::fields::USER_AGENT);
+    if (_ioPendingState != http::RESPONSE_SENDING) {
+        // access logはio_pending_stateがRESPONSE_SENDINGに変更すると同時に記録する
+        std::string remote_addr = _client->getIp();
+        std::string remote_user = "-";
+        std::string request = _parsedRequest.get().originalRequestLine;
+        std::size_t body_bytes_sent = _response.getContentLength();
+        std::string http_referer = getFieldValue(
+            _parsedRequest.get(), http::fields::REFERER);
+        std::string http_user_agent = getFieldValue(
+            _parsedRequest.get(), http::fields::USER_AGENT);
 
-    toolbox::logger::AccessLog::log(
-        remote_addr,
-        remote_user,
-        request,
-        status,
-        body_bytes_sent,
-        http_referer,
-        http_user_agent
-    );
-    _response.sendResponse(_client->getFd());
+        toolbox::logger::AccessLog::log(
+            remote_addr,
+            remote_user,
+            request,
+            status,
+            body_bytes_sent,
+            http_referer,
+            http_user_agent
+        );
+        _ioPendingState = http::RESPONSE_SENDING;
+    }
+    bool endSending = _response.sendResponse(_client->getFd());
+    if (endSending) {
+        _ioPendingState = http::END_RESPONSE;
+    }
 }

--- a/src/http/request/request_impl_response.cpp
+++ b/src/http/request/request_impl_response.cpp
@@ -129,7 +129,10 @@ void http::Request::sendResponse() {
                 return;
             }
             int errorStatus = _errorPageRequest->getResponse().getStatus();
-            if (errorStatus >= 200 && errorStatus < 400) { // [TODO]:magic numberなので後で修正
+
+            const int MIN_SUCCESS_CODE = 200;
+            const int MAX_SUCCESS_CODE = 399;
+            if (errorStatus >= MIN_SUCCESS_CODE && errorStatus <= MAX_SUCCESS_CODE) {
                 propagateErrorPage(&_response, _errorPageRequest->getResponse());
             } else {
                 setDefaultErrorPage(&_response, status);

--- a/src/http/request/request_impl_response.cpp
+++ b/src/http/request/request_impl_response.cpp
@@ -161,6 +161,7 @@ void http::Request::sendResponse() {
             http_user_agent
         );
         _ioPendingState = http::RESPONSE_SENDING;
+        return;
     }
     bool endSending = _response.sendResponse(_client->getFd());
     if (endSending) {

--- a/src/http/response/response.cpp
+++ b/src/http/response/response.cpp
@@ -67,7 +67,7 @@ bool Response::sendResponse(int client_fd) {
         _wholeResponseStr = buildResponse();
         _wholeResponsePtr = _wholeResponseStr.c_str();
     }
-    if (_lengthSent >= _wholeResponseStr.size()) {
+    if (_lengthSent >= static_cast<ssize_t>(_wholeResponseStr.size())) {
         return true;
     }
     ssize_t remaining = _wholeResponseStr.size() - _lengthSent;
@@ -82,7 +82,7 @@ bool Response::sendResponse(int client_fd) {
         throw std::runtime_error(oss.str());
     }
     _lengthSent += sent;
-    if (_lengthSent >= _wholeResponseStr.size()) {
+    if (_lengthSent >= static_cast<ssize_t>(_wholeResponseStr.size())) {
         _wholeResponseStr.clear();
         _wholeResponsePtr = NULL;
         _lengthSent = 0;

--- a/src/http/response/response.hpp
+++ b/src/http/response/response.hpp
@@ -32,7 +32,7 @@ class Response {
 
     void setBody(const std::string& body);
 
-    void sendResponse(int client_fd) const;
+    bool sendResponse(int client_fd);
     static std::string getStatusMessage(int code);
 
     int getStatus() const;
@@ -47,6 +47,9 @@ class Response {
     int _status;
     std::map<FieldName, HeaderField> _headers;
     std::string _body;
+    std::string _wholeResponseStr;
+    const char* _wholeResponsePtr;
+    ssize_t _lengthSent;
 
     std::string buildResponse() const;
 };


### PR DESCRIPTION
## 概要

レスポンスの送信をnon blockingにする

## 変更内容

* レスポンスの送信をnon blockingにする

**Responseクラス**
以下のメンバ変数を追加する。
```cpp
std::string _wholeResponseStr;
const char* _wholeResponsePtr;
ssize_t _lengthSent;
```
`_wholeResponsePtr`は`NULL`で初期化され、レスポンスを送信する直前に`_wholeResponseStr`を作成し、std::string::c_str()を用いて`_wholeResponsePtr`を設定する。
sendするだけであれば、sendをする直前に毎回c_strやsubstrを使えば良いが、c_strはC++98で計算量が保証されていないため、_wholeResponsePtrに保存するようにしている。(substrはそもそも時間がかかりすぎる)


**Requestクラス**
以下のメンバ変数を追加する。
```cpp
toolbox::SharedPtr<http::Request> _errorPageRequest;
```
IOPendingStateを利用して、エラーページ用のリクエストの処理やレスポンスの送信を切り替える


## 関連Issue

* #172

## 影響範囲

* レスポンスの送信
* リクエストの処理全般

## テスト

* 現状では、client_fdをepollに登録する際やイベント処理の際にEPOLLOUTが設定されていないため、non-blockingとして送信できるようにするには、いくつかの修正をする必要がある。 epoll::addClient内で、ev->eventsにEPOLLOUTを追加し、main.cの86行目の条件式を`events[i].events & EPOLLIN`から`events[i].events & (EPOLLIN | EPOLLOUT)`に変更することで、繰り返しepollのイベントによって送信できるようになるはずである。また、`core::IO_BUFFER_SIZE`を小さい値に変更することで、繰り返しの送信をテストしやすくなると思われる。
  * これらの変更は最終的に行う必要があるが、影響範囲が大きいと思われるため、このPRでは扱わず、他のissueで行うことにする。

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | `Request`クラスにエラーページ用のリクエスト処理をサポートするためのメンバ変数が追加されました。 |
| New Feature | `Response`クラスで非ブロッキング送信を実現するための機能が追加されました。 |

このプルリクエストでは、非同期処理を考慮した設計が素晴らしいです。特に、レスポンスの非ブロッキング送信を可能にすることで、システム全体のパフォーマンス向上が期待できます。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->