### PR TITLE
200 update headers in response

### DIFF
--- a/src/http/response/response.cpp
+++ b/src/http/response/response.cpp
@@ -98,7 +98,7 @@ std::string Response::buildResponse() const {
 
     std::map<FieldName, HeaderField>::const_iterator it = _headers.find("Server");
     if (it != _headers.end() && it->second.first) {
-        oss << "Server:" << it->second.second << "\r\n";
+        oss << "Server: " << it->second.second << "\r\n";
     } else {
         oss << "Server: Webserv/Ideal Broccoli\r\n";
     }

--- a/src/http/response/response.cpp
+++ b/src/http/response/response.cpp
@@ -11,6 +11,7 @@
 
 #include "../../core/constant.hpp"
 #include "../../../toolbox/stepmark.hpp"
+#include "../get_gmt.hpp"
 
 namespace http {
 
@@ -95,14 +96,31 @@ std::string Response::buildResponse() const {
     std::ostringstream oss;
     oss << "HTTP/1.1 " << _status << " " << getStatusMessage(_status) << "\r\n";
 
+    std::map<FieldName, HeaderField>::const_iterator it = _headers.find("Server");
+    if (it != _headers.end() && it->second.first) {
+        oss << "Server:" << it->second.second << "\r\n";
+    } else {
+        oss << "Server: Webserv/Ideal Broccoli\r\n";
+    }
+    oss << "Date: " << http::getCurrentGMT() << "\r\n";
+
     for (std::map<FieldName, HeaderField>::const_iterator header = _headers.begin();
-         header != _headers.end(); ++header) {
+        header != _headers.end(); ++header) {
+        if (header->first == "Server" || header->first == "Date" ||
+            header->first == "Content-Length") {
+            continue;
+        }
         if (header->second.first) {
             oss << header->first << ": " << header->second.second << "\r\n";
         }
     }
 
-    oss << "Content-Length: " << _body.size() << "\r\n";
+    const int noContentStatus = 204;
+    const int notModifiedStatus = 304;
+    if (_status != noContentStatus && _status != notModifiedStatus &&
+        _headers.count("Transfer-Encoding") == 0) {
+        oss << "Content-Length: " << _body.size() << "\r\n";
+    }
     oss << "\r\n";
     oss << _body;
 


### PR DESCRIPTION
## 概要

レスポンスのヘッダーを調整する

## 変更内容

* Server/Dateヘッダを追加
* Content-Lengthヘッダを、以下の場合に追加しないようにした
  * ステータスが204
  * ステータスが304
  * Transfer-Encodingがある

## 関連Issue

* #200 

## 影響範囲

* レスポンス

## テスト

* make後、webservを起動し、curl -i localhost:8080を実行
* 任意のブラウザでアクセスし、この変更により不都合が生じないこと確認する

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Bug fix | HTTPレスポンスのヘッダー処理を改善し、特定の条件下で「Content-Length」ヘッダーを除外するようにしました。 |
| New Feature | デフォルトの「Server」ヘッダー値を設定し、「Date」ヘッダーを追加しました。 |

このプルリクエストでは、HTTPレスポンスのヘッダー処理がより正確かつ効率的になり、標準に準拠したレスポンスを提供できるようになりました。特に、ステータスコードやヘッダーの存在に応じた動的な処理が素晴らしいです。これにより、サーバーの信頼性と互換性が向上しています。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->