### PR TITLE
cfunc->cppfunc

### DIFF
--- a/src/http/request/request_parser.cpp
+++ b/src/http/request/request_parser.cpp
@@ -161,9 +161,9 @@ bool RequestParser::isValidFormat() {
     }
     char* endptr = NULL;
     std::size_t majorVersion =
-        strtol(_request.version.substr(5, dotPos).c_str(), &endptr, 10);
+        std::strtol(_request.version.substr(5, dotPos).c_str(), &endptr, 10);
     std::size_t minorVersion =
-        strtol(_request.version.substr(dotPos + 1).c_str(), &endptr, 10);
+        std::strtol(_request.version.substr(dotPos + 1).c_str(), &endptr, 10);
     if (majorVersion < uri::HTTP_MAJOR_VERSION ||
         minorVersion > uri::HTTP_MINOR_VERSION_MAX) {
         _request.httpStatus.set(HttpStatus::BAD_REQUEST);
@@ -272,11 +272,11 @@ void RequestParser::percentDecode(std::string& line) {
 
 bool RequestParser::decodeHex(std::string& hexStr, std::string& decodedStr) {
     if (hexStr.size() != parser::HEX_DIGIT_LENGTH ||
-        !isxdigit(hexStr[0]) || !isxdigit(hexStr[1])) {
+        !std::isxdigit(hexStr[0]) || !std::isxdigit(hexStr[1])) {
         return false;
     }
     char* endptr = NULL;
-    std::size_t hex = strtol(hexStr.c_str(), &endptr, 16);
+    std::size_t hex = std::strtol(hexStr.c_str(), &endptr, 16);
     decodedStr = static_cast<char>(hex);
     if (*endptr != '\0' || hex == '\0') {
         return false;
@@ -403,7 +403,7 @@ void RequestParser::parseChunkedEncoding() {
         std::string hexStr = getBuf()->substr(0, pos + 1);
         std::size_t chunkSize;
         char* endPtr;
-        chunkSize = strtol(hexStr.c_str(), &endPtr, 16);
+        chunkSize = std::strtol(hexStr.c_str(), &endPtr, 16);
         if (*endPtr != *http::symbols::CR) {
             toolbox::logger::StepMark::error("RequestParser: invalid chunk size");
             throw ParseException("");

--- a/src/http/response/method_post.cpp
+++ b/src/http/response/method_post.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <fstream>
 #include <iostream>
+#include <ctime>
 
 #include <sys/stat.h>
 
@@ -33,7 +34,7 @@ bool isFileExists(const std::string& name) {
 }
 
 std::string getTimestamp() {
-    return toolbox::to_string(time(NULL));
+    return toolbox::to_string(std::time(NULL));
 }
 
 void saveToFile(const std::string& filepath, const std::string& content) {

--- a/src/http/response/method_utils.cpp
+++ b/src/http/response/method_utils.cpp
@@ -1,7 +1,8 @@
-#include <unistd.h>
-
 #include <string>
 #include <vector>
+#include <ctime>
+
+#include <unistd.h>
 
 #include "method_utils.hpp"
 
@@ -64,10 +65,11 @@ std::string findFirstExistingIndex(const std::string& path,
 }
 
 std::string getModifiedTime(const struct stat& st) {
-    char timeStr[26];
-    ctime_r(&st.st_mtime, timeStr);
-    timeStr[24] = '\0';  // del newline
-    return std::string(timeStr);
+    char buffer[32];
+    std::tm* fileTime = std::localtime(&st.st_mtime);
+
+    std::strftime(buffer, sizeof(buffer), "%a, %d %b %Y %H:%M:%S", fileTime);
+    return std::string(buffer);
 }
 
 }  // namespace http

--- a/src/http/string_utils.cpp
+++ b/src/http/string_utils.cpp
@@ -56,12 +56,12 @@ bool isEqualCaseInsensitive(const std::string& str1, const std::string& str2) {
 }
 
 std::string decodeHex(const std::string& hexStr) {
-    if (hexStr.size() != 2 || !isxdigit(hexStr[0]) || !isxdigit(hexStr[1])) {
+    if (hexStr.size() != 2 || !std::isxdigit(hexStr[0]) || !std::isxdigit(hexStr[1])) {
         return "";
     }
 
     char* endptr = NULL;
-    std::size_t hex = strtoul(hexStr.c_str(), &endptr, 16);
+    std::size_t hex = std::strtoul(hexStr.c_str(), &endptr, 16);
     if (*endptr != '\0' || hex > 255) {
         return "";
     }

--- a/src/http/string_utils.hpp
+++ b/src/http/string_utils.hpp
@@ -17,7 +17,7 @@ bool isAlnumStr(const std::string& str);
 void trimSpace(std::string* str);
 void skipSpace(std::string* line);
 bool isEqualCaseInsensitive(
-        const std::string& str1, const std::string& str2);
+const std::string& str1, const std::string& str2);
 bool percentDecode(std::string& str, std::string* buf);
 
 }  // namespace utils

--- a/test/http/response/method/delete.cpp
+++ b/test/http/response/method/delete.cpp
@@ -40,9 +40,9 @@ static void setupTestEnvironment() {
 static void cleanupTestEnvironment() {
     chmod("./test_dir/no_permission.html", 0644);
 
-    remove("./test_dir/test.html");
-    remove("./test_dir/index.html");
-    remove("./test_dir/no_permission.html");
+    std::remove("./test_dir/test.html");
+    std::remove("./test_dir/index.html");
+    std::remove("./test_dir/no_permission.html");
 
     rmdir("./test_dir");
 }

--- a/test/http/response/method/get.cpp
+++ b/test/http/response/method/get.cpp
@@ -38,9 +38,9 @@ static void cleanupTestEnvironment() {
     chmod("./test_dir/no_permission.html", 0644);
     chmod("./test_dir/no_permission_dir", 0755);
 
-    remove("./test_dir/test.html");
-    remove("./test_dir/index.html");
-    remove("./test_dir/no_permission.html");
+    std::remove("./test_dir/test.html");
+    std::remove("./test_dir/index.html");
+    std::remove("./test_dir/no_permission.html");
 
     rmdir("./test_dir/empty_dir");
     rmdir("./test_dir/no_permission_dir");

--- a/test/http/response/method/head.cpp
+++ b/test/http/response/method/head.cpp
@@ -42,9 +42,9 @@ static void cleanupTestEnvironment() {
     chmod("./test_dir/no_permission.html", 0644);
     chmod("./test_dir/no_permission_dir", 0755);
 
-    remove("./test_dir/test.html");
-    remove("./test_dir/index.html");
-    remove("./test_dir/no_permission.html");
+    std::remove("./test_dir/test.html");
+    std::remove("./test_dir/index.html");
+    std::remove("./test_dir/no_permission.html");
 
     rmdir("./test_dir/empty_dir");
     rmdir("./test_dir/no_permission_dir");


### PR DESCRIPTION
~

## 概要
cfunc->cppfunc
## 変更内容

* std::がついていない関数にstd::を追加
* 必要なヘッダファイルを追加

## 関連Issue

## 影響範囲

* 

## テスト

* makeし、コンパイルが正常に終了した後localhost:8080にアクセス可能であれば問題ないです

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。
