### PR TITLE
198-argc>=3のとき、segmentation faultします

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -28,6 +28,9 @@ int main(int argc, char* argv[]) {
             config::Config::loadConfig(config::DEFAULT_FILE);
         } else if (argc == 2) {
             config::Config::loadConfig(argv[1]);
+        } else {
+            std::cerr << "Usage: " << argv[0] << " [config_file]" << std::endl;
+            return EXIT_FAILURE;
         }
         toolbox::SharedPtr<config::HttpConfig> httpConfig =
                                         config::Config::getHttpConfig();
@@ -108,7 +111,7 @@ int main(int argc, char* argv[]) {
         }
     } catch (std::exception& e) {
         std::cerr << e.what() << std::endl;
-        return 1;
+        return EXIT_FAILURE;
     }
-    return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## 概要

argcを1, 2しか見ていなかったのでsegvしていた
1, 2以外も条件分岐して即webservを終了させる

## 変更内容

* 

## 関連Issue

* #198

## 影響範囲

* main.cpp

## テスト

* `./webserv`, `./webserv conf/test/cgi_test.conf`の場合、起動すること
* `./webserv [2つ以上の引数がある]` の場合、起動しないこと
* `./webserv [存在しない設定ファイル]`の場合、起動しないこと
* `./webserv [存在する設定ファイル] [1つ以上の引数]`の場合、起動しないこと

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。
