### PR TITLE
208 [code rule] hppファイルで#pragma onceがないものがないかを調べる

### DIFF
--- a/src/http/string_utils.hpp
+++ b/src/http/string_utils.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <string>
 #include <cctype>
 #include <cstdlib>


### PR DESCRIPTION
## 概要

hppファイルで#pragma onceがないものがないかを調べる

## 変更内容

* string_utils.hpp以外、すでに設定されていました

## 関連Issue

* #208

## 影響範囲

* src/http/string_utils.hpp

## テスト

* 1行追加しただけなので特になしです

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。
