### PR TITLE
225 update default error page

### DIFF
--- a/src/http/request/request_impl_response.cpp
+++ b/src/http/request/request_impl_response.cpp
@@ -52,10 +52,18 @@ namespace {
         ss << "<!DOCTYPE html>\n"
             << "<html>\n"
             << "<head>\n"
-            << "<title>Error " << status << "</title>\n"
+            << "<title>" << status;
+        if (http::Response::getStatusMessage(status) != "Unknown Status") {
+            ss << " " << http::Response::getStatusMessage(status);
+        }
+        ss  << " - Ideal Broccoli</title>\n"
             << "</head>\n"
             << "<body>\n"
-            << "<p><strong>Error " << status << "</strong></p>\n"
+            << "<p><strong>" << status;
+        if (http::Response::getStatusMessage(status) != "Unknown Status") {
+            ss << " " << http::Response::getStatusMessage(status);
+        }
+        ss  << "</strong></p>\n"
             << "<p>\n"
             << "The essence you seek, in its most harmonious form, "
             << "resides within the realm of Ideals.<br>\n"


### PR DESCRIPTION
## 概要

デフォルトのエラーページを修正した

## 変更内容

* デフォルトのエラーページを修正した
  * `Error [status]`から`[status] [statusに対応する文字列] - Ideal Broccoli`に変更
  * 本文中にも、[statusに対応する文字列]を含めた

## 関連Issue

* #221 

## 影響範囲

* レスポンス
  * ただし、挙動は変わらず、表示されるものが少し変わるだけ

## テスト

* webservを起動し、いろんなステータスが発生するようにリクエストを送る

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。
