### PR TITLE
recvRequestの戻り値

### DIFF
--- a/src/http/request/recv_request.cpp
+++ b/src/http/request/recv_request.cpp
@@ -103,17 +103,17 @@ bool Request::isValidBodySize() {
     return true;
 }
 
-bool Request::recvRequest() {
+void Request::recvRequest() {
     std::string receivedData;
 
     if (!performRecv(receivedData)) {
         _ioPendingState = NO_IO_PENDING;
         toolbox::logger::StepMark::error("Request: recvRequest: failed to receive data");
-        return false;
+        return;
     }
 
     if (_ioPendingState == START_READING && (receivedData == symbols::CRLF || receivedData == symbols::LF)) {
-        return true;
+        return;
     }
 
     _ioPendingState = REQUEST_READING;
@@ -124,26 +124,25 @@ bool Request::recvRequest() {
         _response.setStatus(_parsedRequest.get().httpStatus.get());
         _ioPendingState = NO_IO_PENDING;
         toolbox::logger::StepMark::error("Request: recvRequest: failed to parse request");
-        return false;
+        return;
     }
     
     if (!isValidBodySize()) {
         if (_ioPendingState == RESPONSE_START) {
-            return false;
+            return;
         }
         _response.setStatus(HttpStatus::PAYLOAD_TOO_LARGE);
         _ioPendingState = NO_IO_PENDING;
         toolbox::logger::StepMark::error("Request: recvRequest: request have "
             "invalid body/content size");
-            return false;
-        }
+        return;
+    }
 
     if (parseStatus == BaseParser::P_COMPLETED) {
         _ioPendingState = NO_IO_PENDING;
         toolbox::logger::StepMark::info("Request: recvRequest: request "
             "received and parsed successfully");
     }
-    return true;
 }
 
 }  // namespace http

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -42,7 +42,7 @@ class Request {
      * @return True if the request was fully received and parsed,
      * false otherwise.
      */
-    bool recvRequest();
+    void recvRequest();
 
     /**
      * @brief Sets the local redirect information for the request.

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -39,8 +39,6 @@ class Request {
      * @brief recieve and parses the raw HTTP request string.
      * @note fetchConfig() is called inside this method to retrieve
      * the configuration for the request.
-     * @return True if the request was fully received and parsed,
-     * false otherwise.
      */
     void recvRequest();
 


### PR DESCRIPTION
~

## 概要
recvRequestの戻り値
## 変更内容

* recvRequestの戻り値をboolからvoidに変更
戻り値をboolにしていたが、使用していないためvoidへと変換した

## 関連Issue

* #123

## 影響範囲

* src/http/request/recv_request.c/hpp

## テスト

* 特になし

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | `Request::recvRequest`メソッドの戻り値を`bool`から`void`に変更し、関数シグネチャと内部ロジックを簡素化しました。 |

このプルリクエストでは、コードのシンプルさと可読性が向上しています。特に、不要な戻り値を削除することで、関数の意図がより明確になり、保守性が高まりました。このような改善は、長期的なプロジェクトの健全性に寄与します。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->