### PR TITLE
227 cgi path info

### DIFF
--- a/src/http/cgi/cgi_execute.cpp
+++ b/src/http/cgi/cgi_execute.cpp
@@ -166,11 +166,10 @@ void CgiExecute::setClientVariables(const toolbox::SharedPtr<Client>& client) {
 void CgiExecute::setRequestVariables(const HTTPRequest& request) {
     _environment[http::cgi::meta::REQUEST_METHOD] = request.method;
     std::string query = request.uri.fullQuery;
-    if (!query.empty()) {
-        _environment[http::cgi::meta::QUERY_STRING] = query;
-    } else {
-        _environment[http::cgi::meta::QUERY_STRING] = "";
+    if (!query.empty() && query[0] == '?') {
+        query = query.substr(1);
     }
+    _environment[http::cgi::meta::QUERY_STRING] = query;
     const HTTPFields::FieldValue& lengthValues =
         request.fields.getFieldValue(http::fields::CONTENT_LENGTH);
     if (!lengthValues.empty()) {

--- a/src/http/cgi/cgi_handler.hpp
+++ b/src/http/cgi/cgi_handler.hpp
@@ -63,6 +63,9 @@ class CgiHandler {
                      size_t redirectCount);
     void copyCgiResponseToResponse(const CgiResponse& cgiResponse,
                             Response& response);
+    std::string buildScriptPath(const std::string& root,
+                               const std::string& uriPath,
+                               const std::vector<std::string>& cgiExtensions) const;
     CgiExecute _execute;
     size_t _redirectCount;
     toolbox::SharedPtr<Client> _client;

--- a/src/http/http_namespace.cpp
+++ b/src/http/http_namespace.cpp
@@ -82,7 +82,7 @@ const size_t TIMEOUT = 30;
 const size_t READ_BUFFER_SIZE = 4096;
 const size_t READ_TIMEOUT_SEC = 1;
 const char* GATEWAY_INTERFACE = "CGI/1.1";
-const char* SERVER_SOFTWARE = "WebServ/1.0";
+const char* SERVER_SOFTWARE = "WebServ-Ideal Broccoli/1.0";
 const char* ENV_PREFIX = "HTTP_";
 namespace meta {
 const char* AUTH_TYPE = "AUTH_TYPE";

--- a/src/http/request/handleRequest.cpp
+++ b/src/http/request/handleRequest.cpp
@@ -51,9 +51,7 @@ void Request::handleRequest() {
         default:
             break;
     }
-    const std::string& targetPath =
-                    http::joinPath(_config.getRoot(), httpRequest.uri.path);
-    bool isCgi = _cgiHandler.isCgiRequest(targetPath,
+    bool isCgi = _cgiHandler.isCgiRequest(httpRequest.uri.path,
                                 _config.getCgiExtensions(),
                                 _config.getCgiPath());
     if (isCgi) {


### PR DESCRIPTION
## 概要

- `http://localhost:8000/script.py/some/path/info`のようなリクエストをCGIとして処理するように修正
その際`/script.py/some/path/info`をCGI環境変数のPATH_INFOに設定する
- QUERY_STRINGに最初の`?`が入っていたので取り除く
- SERVER_SOFTWAREを`WebServ-Ideal Broccoli/1.0`に変更

## 変更内容

* src/http/cgi/cgi_execute.cpp
  * request.uri.fullQueryの最初の?を取り除く 
* src/http/cgi/cgi_handler.cpp
  * パスの先頭から順に.（ドット）を探す
  *  .を見つけたら、次の/まで（なければ文字列終端まで）を拡張子として取得 
* src/http/request/handleRequest.cpp
  * isCGIでしかtargetPath使っていなかったので削除 

## 関連Issue

* #227

## 影響範囲

* CGI

## テスト

* `./webserv`起動後、`http://localhost:8080/script.py/123/456`で動作すること
* `./webserv conf/test/cgi_test.conf`起動後、`http://localhost:8080/env_test.py/123/456`でPATH_INFOが`/env_test.py/123/456`で表示されること

## その他
* 他気になることあればいろんなテストお願いします
* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 