### PR TITLE
235-設定ファイルテスト用 server_name周り

### DIFF
--- a/conf/test/server_name_test.conf
+++ b/conf/test/server_name_test.conf
@@ -1,0 +1,19 @@
+http {
+    allowed_methods GET POST HEAD DELETE;
+    server {
+        listen 9090;
+        server_name test1;
+        root docs/html;
+        location / {
+            index server_name_test1.html;
+        }
+    }
+    server {
+        listen 9090;
+        server_name test2;
+        root docs/html;
+        location / {
+            index server_name_test2.html;
+        }
+    }
+}

--- a/docs/html/server_name_test1.html
+++ b/docs/html/server_name_test1.html
@@ -1,0 +1,1 @@
+server_name test1;

--- a/docs/html/server_name_test2.html
+++ b/docs/html/server_name_test2.html
@@ -1,0 +1,1 @@
+server_name test2;


### PR DESCRIPTION
## 概要

- 設定ファイル内部でportの重複があった時にbindエラーにしてしまっていたため、エラーにならないように修正
外部ですでにportが重複している場合は今までと同じくbindエラーにする

- hostを指定した時にどの設定ファイルのserverブロックが選択されているかのテストケースを追加

## 変更内容

* bindしたportとipをbindする前に見比べる処理を追加

## 関連Issue

* #235 

## 影響範囲

* main.cpp

## テスト

1. `./webserv conf/test/server_name_test.conf` を起動
2. `curl -H "Host: test1" http://localhost:9090` を実行
⇨ `server_name test1` がレスポンスされる
3. `curl -H "Host: test2" http://localhost:9090` を実行
⇨ `server_name test2` がレスポンスされる
4. `curl -H "Host: testabcd" http://localhost:9090` を実行
⇨ `server_name test1` がレスポンスされる (The first server for a host:port will be the defaultの確認)

- すでにport:9090が使用されている状態で、`./webserv conf/test/server_name_test.conf`した時に
`bind() to 0.0.0.0:9090 failed` エラーになること

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Bug fix | `main.cpp`でポートとIPアドレスの重複バインドを防ぐために、`std::set`を使用して既にバインドされたアドレスを追跡するロジックが追加されました。 |

このプルリクエストでは、ネットワーク設定の安定性を向上させるための重要な修正が行われました。重複バインドを防ぐことで、予期しない接続エラーを回避できるようになり、システムの信頼性が向上しました。このような細部にまで気を配った改善は、ユーザー体験を大きく向上させる素晴らしい取り組みです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->