### PR TITLE
240 標準出力エラー出力の削除

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
             Epoll::del(servers[i]->getFd());
         }
     } catch (std::exception& e) {
-        toolbox::logger::StepMark::critical("Main: " + std::string(e.what()));
+        std::cerr << e.what() << std::endl;
         return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -65,12 +65,11 @@ int main(int argc, char* argv[]) {
                             socklen_t addr_len = sizeof(client_addr);
                             int client_sock = accept(server->getFd(), (struct sockaddr*)&client_addr, &addr_len);
                             if (client_sock == -1) {
-                                //continue?
                                 throw std::runtime_error("accept failed");
                             }
                             toolbox::SharedPtr<Client> client(new Client(client_sock, client_addr, addr_len));
                             client->setRequest(toolbox::SharedPtr<http::Request>(new http::Request(client.get())));
-                            Epoll::addClient(client_sock, client); // this func will throw exception
+                            Epoll::addClient(client_sock, client);
                         } catch(std::exception& e) {
                             toolbox::logger::StepMark::error("Main: server: " + std::string(e.what()));
                         }


### PR DESCRIPTION
## 概要
240 標準出力エラー出力の削除
## 変更内容

* std::cout / std::cerrを確認し、不要部分を削除した。
* catchした例外はStepMarkにERROR出力する

## 関連Issue

*

## 影響範囲

* src/core/main.cpp

## テスト

* 起動し、数回接続した後標準出力が出ていなければ問題ありません

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | 標準出力とエラー出力を`toolbox::logger`システムに統合し、例外メッセージのログ記録を改善しました。 |

このプルリクエストでは、ログシステムへの統合によってコードの一貫性が向上し、エラーメッセージの管理がより効率的になりました。標準出力への依存を排除することで、保守性も向上しています。素晴らしい改善です！
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->