### PR TITLE
36 timeoutの管理

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(rg:*)"
-    ],
-    "deny": []
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rg:*)"
+    ],
+    "deny": []
+  }
+}

--- a/src/core/client.hpp
+++ b/src/core/client.hpp
@@ -6,8 +6,10 @@
 
 #include <exception>
 #include <string>
+#include <ctime>
 
 #include "../../toolbox/shared.hpp"
+#include "constant.hpp"
 
 namespace http {
 class Request;
@@ -36,12 +38,14 @@ class Client {
     std::string getIp() const;
     std::string getServerIp() const;
     size_t getServerPort() const;
+    void setLastAccessTime();
 
     toolbox::SharedPtr<http::Request> getRequest() const;
     void setRequest(const toolbox::SharedPtr<http::Request> request);
     bool isBadRequest() const;
     bool isResponseSending() const;
     bool isCgiProcessing() const;
+    bool isClientTimedOut() const;
 
  private:
     Client();
@@ -49,6 +53,7 @@ class Client {
     int _socket_fd;
     struct sockaddr_in _client_addr;
     socklen_t _client_addr_len;
+    time_t _lastAccessTime;
     toolbox::SharedPtr<http::Request> _request;
 
     std::string convertIpToString(uint32_t ip) const;

--- a/src/core/constant.hpp
+++ b/src/core/constant.hpp
@@ -4,4 +4,5 @@
 
 namespace core {
     const std::size_t IO_BUFFER_SIZE = 16 * 1024; // 16 KB
+    const long int CLIENT_TIMEOUT_SECONDS = 60; // 60 seconds
 }

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -60,8 +60,8 @@ int main(int argc, char* argv[]) {
         struct epoll_event events[1000];
         while (1) {
             try {
-                int nfds = Epoll::wait(events, 1000, 1000);
                 Epoll::checkClientTimeouts();
+                int nfds = Epoll::wait(events, 1000, 1000);
                 if (nfds == -1) {
                     throw std::runtime_error("epoll_wait failed");
                 }

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -52,7 +52,8 @@ int main(int argc, char* argv[]) {
         struct epoll_event events[1000];
         while (1) {
             try {
-                int nfds = Epoll::wait(events, 1000, -1);
+                int nfds = Epoll::wait(events, 1000, 1000);
+                Epoll::checkClientTimeouts();
                 if (nfds == -1) {
                     throw std::runtime_error("epoll_wait failed");
                 }
@@ -89,6 +90,7 @@ int main(int argc, char* argv[]) {
                                 continue;
                             } else if ((events[i].events & EPOLLOUT && (client->isResponseSending() || client->isCgiProcessing()))
                                 || (events[i].events & EPOLLIN && !client->isResponseSending())) {
+                                client->setLastAccessTime();
                                 client->getRequest()->run();
                             }
 

--- a/src/event/epoll.cpp
+++ b/src/event/epoll.cpp
@@ -92,6 +92,17 @@ int Epoll::wait(struct epoll_event* events, int maxevents, int timeout) {
     return epoll_wait(epollInstance._epfd, events, maxevents, timeout);
 }
 
+void Epoll::checkClientTimeouts() {
+    Epoll& epollInstance = getInstance();
+    for (std::map<int, struct epoll_event*>::iterator it = epollInstance._events.begin();
+            it != epollInstance._events.end(); ++it) {
+        taggedEventData* tagged = static_cast<taggedEventData*>(it->second->data.ptr);
+        if (tagged->client && tagged->client->isClientTimedOut()) {
+            Epoll::del(tagged->client->getFd());
+        }
+    }
+}
+
 Epoll& Epoll::getInstance() {
     static Epoll instance;
     return instance;

--- a/src/event/epoll.cpp
+++ b/src/event/epoll.cpp
@@ -76,15 +76,15 @@ void Epoll::addClient(int fd, toolbox::SharedPtr<Client> client) {
 void Epoll::del(int fd) {
     Epoll& epollInstance = getInstance();
     std::map<int, struct epoll_event*>::iterator it = epollInstance._events.find(fd);
+    if (epoll_ctl(epollInstance._epfd, EPOLL_CTL_DEL, fd, NULL) == -1) {
+        toolbox::logger::StepMark::error("Epoll::del: epoll_ctl failed for fd: " + toolbox::to_string(fd));
+    }
     if (it != epollInstance._events.end()) {
         struct epoll_event* ev = it->second;
         taggedEventData* tagged = static_cast<taggedEventData*>(ev->data.ptr);
         delete tagged;
         delete ev;
         epollInstance._events.erase(it);
-    }
-    if (epoll_ctl(epollInstance._epfd, EPOLL_CTL_DEL, fd, NULL) == -1) {
-        toolbox::logger::StepMark::error("Epoll::del: epoll_ctl failed for fd: " + toolbox::to_string(fd));
     }
     close(fd);
 }

--- a/src/event/epoll.hpp
+++ b/src/event/epoll.hpp
@@ -28,6 +28,7 @@ class Epoll {
     static void addClient(int fd, toolbox::SharedPtr<Client> client);
     static void del(int fd);
     static int wait(struct epoll_event* events, int maxevents, int timeout);
+    static void checkClientTimeouts();
 
  private:
     Epoll();


### PR DESCRIPTION
## 概要
36 timeoutの管理
## 変更内容

### timeout
* ClientにlastAccessTimeを持たせ、run()が呼ばれるタイミングで更新する。
* mainのepoll_waitが動く前に登録されたepoll._eventsマップを確認し、タイムアウトを検出する。

- epoll_waitはイベントが来るまで１秒間待機する。イベントが来た際は、待機時間を無視してハンドリングに移る
nginxでタイムアウトする時間を確認すると60+-2秒くらいの誤差があり、イベントがこない場合のループ回数を減らすために1秒に設定

- epoll::_eventsから切断対象のfdをvectorに取り出す。
delの中身でeraseが実行されるが、forで回しているiteratorがまだ過去のiteratorを持っているのでセグフォする。

- Epoll::delでepoll_ctlの戻り値が-1だった場合に例外を投げていたが、logを残す方向に変えた。
telnetでタイムアウトの実装をしたところ、evを削除した後にepoll_ctl(del)を実行すると戻り値が-1になる現象があった。
errnoがEBADF(無効なFD)に設定されているためevを削除したタイミングでfdがすでに無効化されているようです。(なぜそうなるか原因まではよくわかりませんでした。)
先にepollの監視対象から削除し、リソースを解放する順番にすることでepoll_ctlが-1を返すことがなくなり、siegeなど試した際もメモリリークが起きなかったためこの変更をしました。


## 関連Issue

* epoll

## 影響範囲

* src/core/client.c/hpp
* src/core/main.cpp
* src/event/epoll.cpp

## テスト

* ./webservを起動し、各種テストを行う
* タイムアウトテスト
```
telnet localhost 8080
```
60秒後にサーバー側が接続を切ります。

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | クライアント接続のタイムアウト管理機能が追加されました。 |
| Refactor | `Epoll::del`関数のエラーハンドリングが改善され、例外ではなくログを記録するようになりました。 |

このプルリクエストは、クライアント接続のタイムアウト管理を導入し、システムの安定性とパフォーマンスを向上させています。特に、エラーハンドリングの改善により、運用時のトラブルシューティングが容易になり、メンテナンス性が高まりました。素晴らしい仕事です！
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->