### PR TITLE
241 処理推移する際にstepmarkを出力する

### DIFF
--- a/src/event/epoll.cpp
+++ b/src/event/epoll.cpp
@@ -106,6 +106,7 @@ void Epoll::checkClientTimeouts() {
     }
 
     for (std::size_t i = 0; i < toRemove.size(); ++i) {
+        toolbox::logger::StepMark::info("Epoll: timeout for client fd: " + toolbox::to_string(toRemove[i]));
         Epoll::del(toRemove[i]);
     }
 }

--- a/src/http/request/handleRequest.cpp
+++ b/src/http/request/handleRequest.cpp
@@ -14,7 +14,7 @@ void Request::handleRequest() {
     }
     if (_response.getStatus() != 200) {
         toolbox::logger::StepMark::error(
-            "Request::handleRequest: Response already set status "
+            "Request: handleRequest: Response already set status "
                 + toolbox::to_string(_response.getStatus()) + " does not handle request");
         return;
     }
@@ -27,7 +27,7 @@ void Request::handleRequest() {
         _response.setStatus(HttpStatus::METHOD_NOT_ALLOWED);
         _ioPendingState = NO_IO_PENDING;
         toolbox::logger::StepMark::error(
-            "Request::handleRequest: Method not allowed: "
+            "Request: handleRequest: Method not allowed: "
                 + httpRequest.method);
         return;
     }
@@ -67,7 +67,7 @@ void Request::handleRequest() {
             _parsedRequest, _config, httpRequest.fields, _response);
     }
 
-    toolbox::logger::StepMark::info("Request::handleRequest: handled request for "
+    toolbox::logger::StepMark::info("Request: handleRequest: handled request for "
         + httpRequest.uri.path + " with method " + httpRequest.method);
 }
 

--- a/src/http/request/request_impl_config.cpp
+++ b/src/http/request/request_impl_config.cpp
@@ -16,6 +16,8 @@ void Request::fetchConfig() {
     }
     if (processReturn(selectedServer->getReturnValue())) {
         _ioPendingState = RESPONSE_START;
+        toolbox::logger::StepMark::info(
+            "Request: fetchConfig: proccessReturn selectedServer found return value");
         return;
     }
     if (!selectLocation(selectedServer)) {
@@ -24,6 +26,8 @@ void Request::fetchConfig() {
     }
     if (processReturn(_config.getReturnValue())) {
         _ioPendingState = RESPONSE_START;
+        toolbox::logger::StepMark::info(
+            "Request: fetchConfig: proccessReturn _config found return value");
         return;
     }
 }

--- a/src/http/request/request_impl_config.cpp
+++ b/src/http/request/request_impl_config.cpp
@@ -17,7 +17,7 @@ void Request::fetchConfig() {
     if (processReturn(selectedServer->getReturnValue())) {
         _ioPendingState = RESPONSE_START;
         toolbox::logger::StepMark::info(
-            "Request: fetchConfig: proccessReturn selectedServer found return value");
+            "Request: fetchConfig: processReturn selectedServer found return value");
         return;
     }
     if (!selectLocation(selectedServer)) {
@@ -27,7 +27,7 @@ void Request::fetchConfig() {
     if (processReturn(_config.getReturnValue())) {
         _ioPendingState = RESPONSE_START;
         toolbox::logger::StepMark::info(
-            "Request: fetchConfig: proccessReturn _config found return value");
+            "Request: fetchConfig: processReturn _config found return value");
         return;
     }
 }

--- a/src/http/request/request_impl_exec.cpp
+++ b/src/http/request/request_impl_exec.cpp
@@ -1,1 +1,0 @@
-#include "request.hpp"

--- a/src/http/request/request_impl_parse.cpp
+++ b/src/http/request/request_impl_parse.cpp
@@ -1,1 +1,0 @@
-#include "request.hpp"

--- a/src/http/request/request_impl_response.cpp
+++ b/src/http/request/request_impl_response.cpp
@@ -97,7 +97,7 @@ void http::Request::sendResponse() {
                 if (std::find(errorPages[i].getCodes().begin(),
                         errorPages[i].getCodes().end(), status)
                     != errorPages[i].getCodes().end()) {
-                    
+
                     _response.setErrorPage(
                         errorPages[i].isOverwrite(),
                         errorPages[i].getNewStatusCode());
@@ -172,6 +172,8 @@ void http::Request::sendResponse() {
                 || _errorPageRequest->getIOPendingState() == http::CGI_OUTPUT_READING
                 || _errorPageRequest->getIOPendingState() == http::CGI_LOCAL_REDIRECT_IO_PENDING) {
                 _ioPendingState = http::ERROR_LOCAL_REDIRECT_IO_PENDING;
+                toolbox::logger::StepMark::info(
+                    "Request: sendResponse: local redirect to error page");
                 return;
             }
             int errorStatus = _errorPageRequest->getResponse().getStatus();
@@ -212,10 +214,14 @@ void http::Request::sendResponse() {
             http_user_agent
         );
         _ioPendingState = http::RESPONSE_SENDING;
+        toolbox::logger::StepMark::info(
+            "Request: sendResponse: ready to send response");
         return;
     }
     bool endSending = _response.sendResponse(_client->getFd());
     if (endSending) {
         _ioPendingState = http::END_RESPONSE;
+        toolbox::logger::StepMark::info(
+            "Request: sendResponse: successfully sent response");
     }
 }


### PR DESCRIPTION
## 概要

## 変更内容

* src/http/request/request_impl_exec.cpp / src/http/request/request_impl_parse.cpp
使用していないため削除
* ioPendingStateが切り替わる際にlogを出力
src/http/request/request_impl_config.cpp / src/http/request/request_impl_response.cpp
cgiの出力を読み取る部分でステータスが変更される部分があるが、複数回動作する可能性があるのでその部分については追加していません


## 関連Issue

* #123

## 影響範囲

* src/request/以下

## テスト

* 正常時、エラー時にlogがのこるか確認
正常時
```
2025-06-21 15:13:56 [INFO] Request: recvRequest: request received and parsed successfully
2025-06-21 15:13:56 [INFO] Request: handleRequest: handled request for / with method GET
2025-06-21 15:13:56 [INFO] Request: sendResponse: ready to send response
2025-06-21 15:13:56 [INFO] Request: sendResponse: successfully sent response
```
エラー時(間に割り込む形で表示)
```
2025-06-21 15:13:57 [INFO] Request: recvRequest: request received and parsed successfully
2025-06-21 15:13:57 [ERROR] runGet: checkFileAccess fail [docs/html/a] 404
2025-06-21 15:13:57 [ERROR] runGet: set status 404
2025-06-21 15:13:57 [INFO] Request: handleRequest: handled request for /a with method GET
2025-06-21 15:13:57 [INFO] Request: sendResponse: ready to send response
2025-06-21 15:13:57 [INFO] Request: sendResponse: successfully sent response
```
## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | クライアントのタイムアウト時にファイルディスクリプタをログ出力する機能を追加しました。 |
| Style | ログメッセージのフォーマットを統一し、一貫性を持たせました。 |
| New Feature | 処理の進行状況を追跡するため、`fetchConfig`と`sendResponse`で詳細なログ出力を追加しました。 |

このプルリクエストは、ログ出力の改善を通じてデバッグや監視が容易になり、システムの信頼性向上に寄与しています。特に、ログの一貫性を保つことで、開発者が迅速に問題を特定できるようになった点が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->