### PR TITLE
247-[CGI] ゾンビプロセスが残ってしまう

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -88,6 +88,9 @@ int main(int argc, char* argv[]) {
                             int client_sock = client->getFd();
 
                             if (isSocketDisconnected(events[i])) {
+                                if (client->isCgiProcessing()) {
+                                    client->getRequest()->terminateActiveCgiProcesses();
+                                }
                                 Epoll::del(client_sock);
                                 continue;
                             } else if ((events[i].events & EPOLLOUT && (client->isResponseSending() || client->isCgiProcessing()))

--- a/src/http/cgi/cgi_execute.cpp
+++ b/src/http/cgi/cgi_execute.cpp
@@ -684,4 +684,8 @@ std::string CgiExecute::extractScriptName(const std::string& requestPath,
     return requestPath;
 }
 
+bool CgiExecute::hasActiveChild() const {
+    return _childPid > 0;
+}
+
 }  // namespace http

--- a/src/http/cgi/cgi_execute.hpp
+++ b/src/http/cgi/cgi_execute.hpp
@@ -63,6 +63,9 @@ class CgiExecute {
     void reset();
     void cleanupPipes();
     bool hasTimedOut() const;
+    bool waitForChildProcess();
+    void terminateChildProcess();
+    bool hasActiveChild() const;
 
  private:
     CgiExecute(const CgiExecute& other);
@@ -103,10 +106,8 @@ class CgiExecute {
     bool isChildProcessEnded();
     std::string extractScriptName(const std::string& requestPath,
                                 const std::string& scriptPath) const;
-    bool waitForChildProcess();
     bool handleProcessExit(int status);
     bool validateScriptPath(const std::string& scriptPath) const;
-    void terminateChildProcess();
     void wrapClose(int& fd);
     bool setNonBlocking(int fd);
 

--- a/src/http/cgi/cgi_handler.hpp
+++ b/src/http/cgi/cgi_handler.hpp
@@ -33,6 +33,7 @@ class CgiHandler {
                        const http::IOPendingState ioPendingState);
     void setRedirectCount(size_t count) { _redirectCount = count; }
     void reset();
+    void forceTerminate();
 
  private:
     CgiHandler(const CgiHandler& other);

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -98,6 +98,11 @@ class Request {
      */
     const std::string& getUploadPath() const;
 
+    /**
+     * @brief Terminates any active CGI processes.
+     */
+    void terminateActiveCgiProcesses();
+
  private:
     http::RequestParser _parsedRequest;
     config::LocationConfig _config;

--- a/src/http/request/request_impl_basic.cpp
+++ b/src/http/request/request_impl_basic.cpp
@@ -42,3 +42,7 @@ void http::Request::setErrorInternalRedirect() {
 const std::string& http::Request::getUploadPath() const {
     return _config.getUploadStore();
 }
+
+void http::Request::terminateActiveCgiProcesses() {
+    _cgiHandler.forceTerminate();
+}


### PR DESCRIPTION
## 概要

* `curl -v http://localhost:8080/document.py`などのCGIスクリプト実行後、ゾンビプロセスが残ってしまう
* ゾンビプロセスで溢れてしまった後、CGIスクリプトを実行しようとするとfork errorとなり、CGIスクリプトが実行できずサーバからは500エラーでしか返ってこなくなる

## 変更内容

* forceTerminate（子プロセス強制終了関数）を追加
* CGIの処理完了時、エラー時、クライアントからCGI処理中に切断された時に子プロセスが実行中であればkillする処理を追加

## 関連Issue

* #247 

## 影響範囲

* CGI全般
* サーバがcgi処理中にクライアントに切断された時

## テスト

* 単独
  * `./webserv conf/test/cgi_test.conf`起動
  * `curl -i http://localhost:8080/document.py`等のCGIスクリプトを実行
  * `ps aux | grep defunct`で `実行時刻 0:00 [python3] <defunct>`が存在しないことを確認

* ちょい負荷加える
  * `./webserv conf/test/cgi_test.conf`起動
  * `siege http://127.0.0.1:8080/document.py`等のCGIスクリプトで多めのリクエストを送信
  *   何秒後かにsiegeをstopさせて、`ps aux | grep defunct`で `実行時刻 0:00 [python3] <defunct>`が存在しないことを確認

## その他

* broken pipeのエラーがサーバ側に出る可能性がありますが、そのエラーによってサーバが落ちることはない（はず）ので一旦無視しています。対応としてはCGIスクリプト側でSIGPIPEのシステムコールに対して無視や例外対応を行うと表示されなくなります。すでにサーバ側がpipeを閉じてしまっている時にpython側（インタープリタによって？）でSIGPIPEのシステムコールを受け取るらしい。サーバ側で表示させない方法は現状思いついていません
```
import signal
signal.signal(signal.SIGPIPE, signal.SIG_DFL)
//SIGPIPEのデフォルト動作（プロセス終了、エラーメッセージなし）に設定
```

* SIGPIPE： 切断されたソケットやパイプに書き込もうとした際に発生するシグナル
* 参考：https://shuzo-kino.hateblo.jp/entry/2023/01/19/235802

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| New Feature | CGIプロセスの管理が強化され、クライアント切断時にアクティブなCGIプロセスを終了する機能が追加されました。 |
| Bug fix | ゾンビプロセスを防ぐための処理が改善され、CGIスクリプト実行後に子プロセスが適切に終了するようになりました。 |

このプルリクエストでは、CGIプロセス管理の堅牢性が大幅に向上しており、特にゾンビプロセスを防ぐためのロジックがしっかりと組み込まれています。コードの可読性も高く、メンテナンスが容易です。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->