### PR TITLE
207 code rule コードのフォーマットcopyright行を入れる

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 
 #include "config.hpp"

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -52,12 +52,12 @@ class Config {
     static Config& getConfig() { return getInstance(); }
     static const toolbox::SharedPtr<config::HttpConfig>&
                     getHttpConfig() { return getInstance()._httpConfig; }
-    static size_t getTokenCount() { return getInstance()._tokenCount; }
+    static std::size_t getTokenCount() { return getInstance()._tokenCount; }
     static void setHttpConfig
     (const toolbox::SharedPtr<config::HttpConfig>& httpConfig) {
         getInstance()._httpConfig = httpConfig;
     }
-    static void setTokenCount(const size_t tokenCount) {
+    static void setTokenCount(const std::size_t tokenCount) {
         getInstance()._tokenCount = tokenCount;
     }
 
@@ -68,7 +68,7 @@ class Config {
     Config& operator=(const Config& other);
 
     toolbox::SharedPtr<config::HttpConfig> _httpConfig;
-    size_t _tokenCount;
+    std::size_t _tokenCount;
 
     static Config& getInstance();
 };

--- a/src/config/config_base.cpp
+++ b/src/config/config_base.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 

--- a/src/config/config_base.hpp
+++ b/src/config/config_base.hpp
@@ -24,7 +24,7 @@ namespace config {
  * errorPage.setPath("/404.html");
  * 
  * // Accessing the configured settings
- * const std::vector<size_t>& codes = errorPage.getCodes(); // Returns [404, 403]
+ * const std::vector<std::size_t>& codes = errorPage.getCodes(); // Returns [404, 403]
  * const std::string& path = errorPage.getPath();           // Returns "/404.html"
  * @endcode
  */
@@ -35,8 +35,8 @@ class ErrorPage {
     ErrorPage& operator=(const ErrorPage&);
     ~ErrorPage();
 
-    void addCode(size_t code) { _codes.push_back(code); }
-    const std::vector<size_t>& getCodes() const { return _codes; }
+    void addCode(std::size_t code) { _codes.push_back(code); }
+    const std::vector<std::size_t>& getCodes() const { return _codes; }
     const std::string& getPath() const { return _path; }
     void setPath(const std::string& path) { _path = path; }
 
@@ -46,7 +46,7 @@ class ErrorPage {
     void setNewStatusCode(int newStatusCode) { _newStatusCode = newStatusCode; }
 
  private:
-    std::vector<size_t> _codes;
+    std::vector<std::size_t> _codes;
     std::string _path;
     bool _overwrite;  // Indicates if the HTTP status code should be overwritten
     int _newStatusCode;
@@ -67,7 +67,7 @@ class ErrorPage {
  * listen.setDefaultServer(true);
  * 
  * // Accessing the configured settings
- * size_t port = listen.getPort();                // Returns 80
+ * std::size_t port = listen.getPort();                // Returns 80
  * const std::string& ip = listen.getIp();        // Returns "0.0.0.0"
  * bool isDefault = listen.isDefaultServer();     // Returns true
  * @endcode
@@ -79,15 +79,15 @@ class Listen {
     Listen& operator=(const Listen&);
     ~Listen();
 
-    size_t getPort() const { return _port; }
+    std::size_t getPort() const { return _port; }
     const std::string& getIp() const { return _ip; }
     bool isDefaultServer() const { return _defaultServer; }
-    void setPort(size_t port) { _port = port; }
+    void setPort(std::size_t port) { _port = port; }
     void setIp(const std::string& ip) { _ip = ip; }
     void setDefaultServer(bool defaultServer) { _defaultServer = defaultServer; }
 
  private:
-    size_t _port;
+    std::size_t _port;
     std::string _ip;
     bool _defaultServer;
 };
@@ -154,7 +154,7 @@ class ServerName {
  * redirect.setHasReturnValue(true);
  * 
  * // Accessing the configured settings
- * size_t code = redirect.getStatusCode();                // Returns 301
+ * std::size_t code = redirect.getStatusCode();                // Returns 301
  * const std::string& url = redirect.getTextOrUrl();      // Returns "https://example.com"
  * bool hasUrl = redirect.isTextOrUrlSetting();           // Returns true
  * bool hasValue = redirect.hasReturnValue();             // Returns true
@@ -167,17 +167,17 @@ class Return {
     Return(const Return&);
     Return& operator=(const Return&);
 
-    size_t getStatusCode() const { return _statusCode; }
+    std::size_t getStatusCode() const { return _statusCode; }
     const std::string& getTextOrUrl() const { return _textOrUrl; }
     bool isTextOrUrlSetting() const { return _isTextOrUrlSetting; }
     bool hasReturnValue() const { return _hasReturnValue; }
-    void setStatusCode(size_t code) { _statusCode = code; }
+    void setStatusCode(std::size_t code) { _statusCode = code; }
     void setTextOrUrl(const std::string& textOrUrl) { _textOrUrl = textOrUrl; }
     void setIsTextOrUrlSetting(bool isTextOrUrlSetting) { _isTextOrUrlSetting = isTextOrUrlSetting; }
     void setHasReturnValue(bool hasValue) { _hasReturnValue = hasValue; }
 
  private:
-    size_t _statusCode;
+    std::size_t _statusCode;
     std::string _textOrUrl;
     bool _isTextOrUrlSetting;
     bool _hasReturnValue;
@@ -215,7 +215,7 @@ class Return {
  * const std::string& root = config->getRoot();           // Returns "/var/www"
  * bool autoindex = config->getAutoindex();               // Returns true
  * const std::vector<std::string>& methods = config->getAllowedMethods(); // Returns ["GET", "POST"]
- * size_t maxBodySize = config->getClientMaxBodySize();   // Returns default or configured value
+ * std::size_t maxBodySize = config->getClientMaxBodySize();   // Returns default or configured value
  * @endcode
  */
 class ConfigBase {
@@ -229,7 +229,7 @@ class ConfigBase {
     bool getAutoindex() const { return _autoindex; }
     const std::vector<std::string>& getCgiExtensions() const { return _cgiExtensions; }
     const std::string& getCgiPath() const { return _cgiPath; }
-    size_t getClientMaxBodySize() const { return _clientMaxBodySize; }
+    std::size_t getClientMaxBodySize() const { return _clientMaxBodySize; }
     const std::vector<ErrorPage>& getErrorPages() const { return _errorPages; }
     const std::vector<std::string>& getIndices() const { return _indices; }
     const std::string& getRoot() const { return _root; }
@@ -241,7 +241,7 @@ class ConfigBase {
     void setCgiExtensions(const std::vector<std::string>& extensions) { _cgiExtensions = extensions; }
     void addCgiExtension(const std::string& extension) { _cgiExtensions.push_back(extension); }
     void setCgiPath(const std::string& path) { _cgiPath = path; }
-    void setClientMaxBodySize(size_t size) { _clientMaxBodySize = size; }
+    void setClientMaxBodySize(std::size_t size) { _clientMaxBodySize = size; }
     void setErrorPages(const std::vector<ErrorPage>& pages) { _errorPages = pages; }
     void addErrorPage(const ErrorPage& page) { _errorPages.push_back(page); }
     void setIndices(const std::vector<std::string>& indices) { _indices = indices; }
@@ -254,7 +254,7 @@ class ConfigBase {
     bool _autoindex;
     std::vector<std::string> _cgiExtensions;
     std::string _cgiPath;
-    size_t _clientMaxBodySize;
+    std::size_t _clientMaxBodySize;
     std::vector<ErrorPage> _errorPages;
     std::vector<std::string> _indices;
     std::string _root;

--- a/src/config/config_base.hpp
+++ b/src/config/config_base.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/config/config_directive_handler.cpp
+++ b/src/config/config_directive_handler.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <map>
 #include <string>
 #include <vector>

--- a/src/config/config_directive_handler.cpp
+++ b/src/config/config_directive_handler.cpp
@@ -71,7 +71,7 @@ void DirectiveParser::initDirectiveInfo() {
     _directiveInfo[config::directive::RETURN] = info;
 }
 
-bool DirectiveParser::parseDirective(const std::vector<std::string>& tokens, size_t* pos, const std::string& directive, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::parseDirective(const std::vector<std::string>& tokens, std::size_t* pos, const std::string& directive, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     if (directive == config::directive::ROOT) {
         return handleRootDirective(tokens, pos, http, server, location);
     } else if (directive == config::directive::INDEX) {
@@ -111,7 +111,7 @@ bool DirectiveParser::isDirectiveAllowedInContext(const std::string& directive, 
     return true;
 }
 
-bool DirectiveParser::handleAllowedMethodsDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleAllowedMethodsDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     std::vector<std::string> methods;
     if (http) {
         methods = http->getAllowedMethods();
@@ -133,7 +133,7 @@ bool DirectiveParser::handleAllowedMethodsDirective(const std::vector<std::strin
     return result;
 }
 
-bool DirectiveParser::handleAutoindexDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleAutoindexDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     bool autoindex;
     if (http) {
         autoindex = http->getAutoindex();
@@ -157,7 +157,7 @@ bool DirectiveParser::handleAutoindexDirective(const std::vector<std::string>& t
     return result;
 }
 
-bool DirectiveParser::handleCgiExtensionDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleCgiExtensionDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     std::vector<std::string> extensions;
     if (http) {
         extensions = http->getCgiExtensions();
@@ -181,7 +181,7 @@ bool DirectiveParser::handleCgiExtensionDirective(const std::vector<std::string>
     return result;
 }
 
-bool DirectiveParser::handleCgiPathDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleCgiPathDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     std::string cgiPath;
     if (http) {
         cgiPath = http->getCgiPath();
@@ -205,7 +205,7 @@ bool DirectiveParser::handleCgiPathDirective(const std::vector<std::string>& tok
     return result;
 }
 
-bool DirectiveParser::handleErrorPageDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleErrorPageDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     std::vector<ErrorPage> errorPages;
     if (http) {
         errorPages = http->getErrorPages();
@@ -219,15 +219,15 @@ bool DirectiveParser::handleErrorPageDirective(const std::vector<std::string>& t
     bool result = parseErrorPageDirective(tokens, pos, &errorPages);
     if (result) {
         if (http) {
-            for (size_t i = 0; i < errorPages.size(); ++i) {
+            for (std::size_t i = 0; i < errorPages.size(); ++i) {
                 http->addErrorPage(errorPages[i]);
             }
         } else if (server) {
-            for (size_t i = 0; i < errorPages.size(); ++i) {
+            for (std::size_t i = 0; i < errorPages.size(); ++i) {
                 server->addErrorPage(errorPages[i]);
             }
         } else if (location) {
-            for (size_t i = 0; i < errorPages.size(); ++i) {
+            for (std::size_t i = 0; i < errorPages.size(); ++i) {
                 location->addErrorPage(errorPages[i]);
             }
         }
@@ -235,8 +235,8 @@ bool DirectiveParser::handleErrorPageDirective(const std::vector<std::string>& t
     return result;
 }
 
-bool DirectiveParser::handleClientMaxBodySizeDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
-    size_t size;
+bool DirectiveParser::handleClientMaxBodySizeDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+    std::size_t size;
     if (http) {
         size = http->getClientMaxBodySize();
     } else if (server) {
@@ -259,7 +259,7 @@ bool DirectiveParser::handleClientMaxBodySizeDirective(const std::vector<std::st
     return result;
 }
 
-bool DirectiveParser::handleIndexDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleIndexDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     std::vector<std::string> indices;
     if (http) {
         indices = http->getIndices();
@@ -283,7 +283,7 @@ bool DirectiveParser::handleIndexDirective(const std::vector<std::string>& token
     return result;
 }
 
-bool DirectiveParser::handleListenDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleListenDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     if (http) {
         throwConfigError("\"" + std::string(config::directive::LISTEN) + "\" directive is not allowed here");
     } else if (location) {
@@ -300,7 +300,7 @@ bool DirectiveParser::handleListenDirective(const std::vector<std::string>& toke
     return result;
 }
 
-bool DirectiveParser::handleReturnDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleReturnDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     if (http) {
         throwConfigError("\"" + std::string(config::directive::RETURN) + "\" directive is not allowed here");
     }
@@ -323,7 +323,7 @@ bool DirectiveParser::handleReturnDirective(const std::vector<std::string>& toke
     return result;
 }
 
-bool DirectiveParser::handleRootDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleRootDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     std::string root;
     if (http) {
         root = http->getRoot();
@@ -347,7 +347,7 @@ bool DirectiveParser::handleRootDirective(const std::vector<std::string>& tokens
     return result;
 }
 
-bool DirectiveParser::handleServerNameDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleServerNameDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     if (http) {
         throwConfigError("\"" + std::string(config::directive::SERVER_NAME) + "\" directive is not allowed here");
     } else if (location) {
@@ -364,7 +364,7 @@ bool DirectiveParser::handleServerNameDirective(const std::vector<std::string>& 
     return result;
 }
 
-bool DirectiveParser::handleUploadStoreDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
+bool DirectiveParser::handleUploadStoreDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location) {
     std::string uploadStore;
     if (http) {
         uploadStore = http->getUploadStore();
@@ -388,7 +388,7 @@ bool DirectiveParser::handleUploadStoreDirective(const std::vector<std::string>&
     return result;
 }
 
-bool DirectiveParser::handleDuplicateDirective(const std::string& directiveName, const std::vector<std::string>& tokens, size_t* pos, bool* shouldSkip) {
+bool DirectiveParser::handleDuplicateDirective(const std::string& directiveName, const std::vector<std::string>& tokens, std::size_t* pos, bool* shouldSkip) {
     *shouldSkip = false;
     if (isAllowedDuplicate(directiveName)) {
         return true;
@@ -411,8 +411,8 @@ bool DirectiveParser::isAllowedDuplicate(const std::string& directiveName) {
         config::directive::SERVER_NAME,
         config::directive::LISTEN,
     };
-    const size_t allowedCount = sizeof(allowedDuplicates) / sizeof(allowedDuplicates[0]);
-    for (size_t i = 0; i < allowedCount; ++i) {
+    const std::size_t allowedCount = sizeof(allowedDuplicates) / sizeof(allowedDuplicates[0]);
+    for (std::size_t i = 0; i < allowedCount; ++i) {
         if (directiveName == allowedDuplicates[i]) {
             return true;
         }
@@ -424,8 +424,8 @@ bool DirectiveParser::isIgnoredDuplicate(const std::string& directiveName) {
     const std::string ignoredDuplicates[] = {
         config::directive::RETURN
     };
-    const size_t ignoredCount = sizeof(ignoredDuplicates) / sizeof(ignoredDuplicates[0]);
-    for (size_t i = 0; i < ignoredCount; ++i) {
+    const std::size_t ignoredCount = sizeof(ignoredDuplicates) / sizeof(ignoredDuplicates[0]);
+    for (std::size_t i = 0; i < ignoredCount; ++i) {
         if (directiveName == ignoredDuplicates[i]) {
             return true;
         }
@@ -433,7 +433,7 @@ bool DirectiveParser::isIgnoredDuplicate(const std::string& directiveName) {
     return false;
 }
 
-void DirectiveParser::skipUntilSemicolon(const std::vector<std::string>& tokens, size_t* pos) {
+void DirectiveParser::skipUntilSemicolon(const std::vector<std::string>& tokens, std::size_t* pos) {
     while (*pos < tokens.size() && tokens[*pos] != config::directive::SEMICOLON) {
         (*pos)++;
     }

--- a/src/config/config_directive_handler.hpp
+++ b/src/config/config_directive_handler.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/config/config_directive_handler.hpp
+++ b/src/config/config_directive_handler.hpp
@@ -38,21 +38,21 @@ class DirectiveParser {
  public:
     DirectiveParser();
     ~DirectiveParser();
-    bool parseDirective(const std::vector<std::string>& tokens, size_t* pos, const std::string& directive, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool parseRootDirective(const std::vector<std::string>& tokens, size_t* pos, std::string* root);
-    bool parseIndexDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<std::string>* index);
-    bool parseAutoindexDirective(const std::vector<std::string>& tokens, size_t* pos, bool* autoindex);
-    bool parseAllowedMethodsDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<std::string>* allowedMethods);
-    bool parseErrorPageDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<ErrorPage>* errorPages);
-    bool parseUploadStoreDirective(const std::vector<std::string>& tokens, size_t* pos, std::string* uploadStore);
-    bool parseCgiPathDirective(const std::vector<std::string>& tokens, size_t* pos, std::string* cgiPath);
-    bool parseCgiExtensionDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<std::string>* cgiExtensions);
-    bool parseReturnDirective(const std::vector<std::string>& tokens, size_t* pos, Return* returnValue);
-    bool parseClientMaxBodySize(const std::vector<std::string>& tokens, size_t* pos, size_t* clientMaxBodySize);
-    bool parseListenDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<Listen>* listen);
-    bool parseServerNameDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<config::ServerName>* serverNames);
+    bool parseDirective(const std::vector<std::string>& tokens, std::size_t* pos, const std::string& directive, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool parseRootDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::string* root);
+    bool parseIndexDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<std::string>* index);
+    bool parseAutoindexDirective(const std::vector<std::string>& tokens, std::size_t* pos, bool* autoindex);
+    bool parseAllowedMethodsDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<std::string>* allowedMethods);
+    bool parseErrorPageDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<ErrorPage>* errorPages);
+    bool parseUploadStoreDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::string* uploadStore);
+    bool parseCgiPathDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::string* cgiPath);
+    bool parseCgiExtensionDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<std::string>* cgiExtensions);
+    bool parseReturnDirective(const std::vector<std::string>& tokens, std::size_t* pos, Return* returnValue);
+    bool parseClientMaxBodySize(const std::vector<std::string>& tokens, std::size_t* pos, std::size_t* clientMaxBodySize);
+    bool parseListenDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<Listen>* listen);
+    bool parseServerNameDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<config::ServerName>* serverNames);
     bool isDirectiveAllowedInContext(const std::string& directive, DirectiveContext context) const;
-    bool handleDuplicateDirective(const std::string& directiveName, const std::vector<std::string>& tokens, size_t* pos, bool* shouldSkip);
+    bool handleDuplicateDirective(const std::string& directiveName, const std::vector<std::string>& tokens, std::size_t* pos, bool* shouldSkip);
 
  private:
     DirectiveParser(const DirectiveParser& other);
@@ -60,21 +60,21 @@ class DirectiveParser {
 
     std::map<std::string, DirectiveInfo> _directiveInfo;
     void initDirectiveInfo();
-    bool handleAllowedMethodsDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleAutoindexDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleRootDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleIndexDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleErrorPageDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleUploadStoreDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleCgiPathDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleCgiExtensionDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleReturnDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleClientMaxBodySizeDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleListenDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
-    bool handleServerNameDirective(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleAllowedMethodsDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleAutoindexDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleRootDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleIndexDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleErrorPageDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleUploadStoreDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleCgiPathDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleCgiExtensionDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleReturnDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleClientMaxBodySizeDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleListenDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
+    bool handleServerNameDirective(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* http, config::ServerConfig* server, config::LocationConfig* location);
     bool isAllowedDuplicate(const std::string& directiveName);
     bool isIgnoredDuplicate(const std::string& directiveName);
-    void skipUntilSemicolon(const std::vector<std::string>& tokens, size_t* pos);
+    void skipUntilSemicolon(const std::vector<std::string>& tokens, std::size_t* pos);
 };
 
 }  // namespace config

--- a/src/config/config_directive_parser.cpp
+++ b/src/config/config_directive_parser.cpp
@@ -18,7 +18,7 @@
 
 namespace config {
 
-bool expectSemicolon(const std::vector<std::string>& tokens, size_t* pos, const std::string directiveName) {
+bool expectSemicolon(const std::vector<std::string>& tokens, std::size_t* pos, const std::string directiveName) {
     if (*pos >= tokens.size() || tokens[*pos] != config::directive::SEMICOLON) {
         throwConfigError("invalid number of arguments in \"" + directiveName + "\" directive");
     }
@@ -26,15 +26,15 @@ bool expectSemicolon(const std::vector<std::string>& tokens, size_t* pos, const 
     return true;
 }
 
-bool parseSize(const std::string& str, size_t* result) {
+bool parseSize(const std::string& str, std::size_t* result) {
     if (!result || str.empty()) {
         toolbox::logger::StepMark::error("Unexpected Error");
         return false;
     }
     char unit = str[str.size() - 1];
-    size_t len = str.size();
-    size_t scale = 1;
-    size_t max;
+    std::size_t len = str.size();
+    std::size_t scale = 1;
+    std::size_t max;
     switch (unit) {
         case 'K':
         case 'k':
@@ -62,7 +62,7 @@ bool parseSize(const std::string& str, size_t* result) {
             max = std::numeric_limits<off_t>::max();
     }
     std::string num_str = str.substr(0, len);
-    size_t value;
+    std::size_t value;
     if (!stringToSizeT(num_str, &value)) {
         return false;
     }
@@ -91,7 +91,7 @@ void validateHost(const std::string& host, const std::string& fullValue) {
     freeaddrinfo(result);
 }
 
-bool DirectiveParser::parseAllowedMethodsDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<std::string>* methods) {
+bool DirectiveParser::parseAllowedMethodsDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<std::string>* methods) {
     if (!methods || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::ALLOWED_METHODS));
         return false;
@@ -102,7 +102,7 @@ bool DirectiveParser::parseAllowedMethodsDirective(const std::vector<std::string
     while (*pos < tokens.size() && tokens[*pos] != config::directive::SEMICOLON) {
         std::string method = tokens[*pos];
         bool isValidMethod = false;
-        for (size_t i = 0; i < config::method::ALLOWED_METHODS_COUNT; ++i) {
+        for (std::size_t i = 0; i < config::method::ALLOWED_METHODS_COUNT; ++i) {
             if (isCaseInsensitiveIdentical(method, config::method::ALLOWED_METHODS[i])) {
                 isValidMethod = true;
                 break;
@@ -117,7 +117,7 @@ bool DirectiveParser::parseAllowedMethodsDirective(const std::vector<std::string
     return expectSemicolon(tokens, pos, std::string(config::directive::ALLOWED_METHODS));
 }
 
-bool DirectiveParser::parseAutoindexDirective(const std::vector<std::string>& tokens, size_t* pos, bool* autoindex) {
+bool DirectiveParser::parseAutoindexDirective(const std::vector<std::string>& tokens, std::size_t* pos, bool* autoindex) {
     if (!autoindex || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::AUTOINDEX));
         return false;
@@ -136,7 +136,7 @@ bool DirectiveParser::parseAutoindexDirective(const std::vector<std::string>& to
     return expectSemicolon(tokens, pos, std::string(config::directive::AUTOINDEX));
 }
 
-bool DirectiveParser::parseCgiExtensionDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<std::string>* cgiExtensions) {
+bool DirectiveParser::parseCgiExtensionDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<std::string>* cgiExtensions) {
     if (!cgiExtensions || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::CGI_EXTENSION));
         return false;
@@ -151,7 +151,7 @@ bool DirectiveParser::parseCgiExtensionDirective(const std::vector<std::string>&
     return expectSemicolon(tokens, pos, std::string(config::directive::CGI_EXTENSION));
 }
 
-bool DirectiveParser::parseCgiPathDirective(const std::vector<std::string>& tokens, size_t* pos, std::string* cgiPath) {
+bool DirectiveParser::parseCgiPathDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::string* cgiPath) {
     if (!cgiPath || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::CGI_PATH));
         return false;
@@ -164,7 +164,7 @@ bool DirectiveParser::parseCgiPathDirective(const std::vector<std::string>& toke
     return expectSemicolon(tokens, pos, std::string(config::directive::CGI_PATH));
 }
 
-bool DirectiveParser::parseClientMaxBodySize(const std::vector<std::string>& tokens, size_t* pos, size_t* clientMaxBodySize) {
+bool DirectiveParser::parseClientMaxBodySize(const std::vector<std::string>& tokens, std::size_t* pos, std::size_t* clientMaxBodySize) {
     if (*pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::CLIENT_MAX_BODY_SIZE));
         return false;
@@ -179,7 +179,7 @@ bool DirectiveParser::parseClientMaxBodySize(const std::vector<std::string>& tok
     return expectSemicolon(tokens, pos, std::string(config::directive::CLIENT_MAX_BODY_SIZE));
 }
 
-bool DirectiveParser::parseErrorPageDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<ErrorPage>* errorPages) {
+bool DirectiveParser::parseErrorPageDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<ErrorPage>* errorPages) {
     if (!errorPages || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::ERROR_PAGE));
         return false;
@@ -188,10 +188,10 @@ bool DirectiveParser::parseErrorPageDirective(const std::vector<std::string>& to
         throwConfigError("invalid number of arguments in \"" + std::string(config::directive::ERROR_PAGE) + "\" directive");
     }
     ErrorPage errorPage;
-    std::vector<size_t> codes;
+    std::vector<std::size_t> codes;
     while (*pos < tokens.size() && tokens[*pos] != config::directive::SEMICOLON) {
         std::string token = tokens[(*pos)];
-        size_t codeValue;
+        std::size_t codeValue;
         if (config::stringToSizeT(token, &codeValue)) {
             if (codeValue < config::directive::MIN_ERROR_PAGE_CODE || 
                 codeValue > config::directive::MAX_ERROR_PAGE_CODE) {
@@ -235,7 +235,7 @@ bool DirectiveParser::parseErrorPageDirective(const std::vector<std::string>& to
     if (tokens[*pos] != config::directive::SEMICOLON) {
         throwConfigError("invalid value in \"" + tokens[*pos] + "\"");
     }
-    for (size_t i = 0; i < codes.size(); ++i) {
+    for (std::size_t i = 0; i < codes.size(); ++i) {
         errorPage.addCode(codes[i]);
     }
     errorPage.setPath(path);
@@ -243,7 +243,7 @@ bool DirectiveParser::parseErrorPageDirective(const std::vector<std::string>& to
     return expectSemicolon(tokens, pos, std::string(config::directive::ERROR_PAGE));
 }
 
-bool DirectiveParser::parseIndexDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<std::string>* indexFiles) {
+bool DirectiveParser::parseIndexDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<std::string>* indexFiles) {
     if (!indexFiles || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::INDEX));
         return false;
@@ -262,7 +262,7 @@ bool DirectiveParser::parseIndexDirective(const std::vector<std::string>& tokens
     return expectSemicolon(tokens, pos, std::string(config::directive::INDEX));
 }
 
-bool DirectiveParser::parseListenDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<Listen>* listen) {
+bool DirectiveParser::parseListenDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<Listen>* listen) {
     if (!listen || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::LISTEN));
         return false;
@@ -272,8 +272,8 @@ bool DirectiveParser::parseListenDirective(const std::vector<std::string>& token
     }
     std::string listenValue = tokens[(*pos)++];
     Listen tmpListen;
-    size_t port;
-    size_t colonPos = listenValue.find(config::token::COLON);
+    std::size_t port;
+    std::size_t colonPos = listenValue.find(config::token::COLON);
     if (colonPos != std::string::npos) {
         std::string portStr = listenValue.substr(colonPos + 1);
         if (!config::stringToSizeT(portStr, &port))
@@ -314,7 +314,7 @@ bool DirectiveParser::parseListenDirective(const std::vector<std::string>& token
     } else {
         tmpListen.setDefaultServer(false);
     }
-    for (size_t i = 0; i < listen->size(); ++i) {
+    for (std::size_t i = 0; i < listen->size(); ++i) {
         if ((*listen)[i].getPort() == tmpListen.getPort() && (*listen)[i].getIp() == tmpListen.getIp()) {
             throwConfigError("duplicate ip port \"" + std::string(config::directive::LISTEN) + "\" directive");
         }
@@ -324,7 +324,7 @@ bool DirectiveParser::parseListenDirective(const std::vector<std::string>& token
     return expectSemicolon(tokens, pos, std::string(config::directive::LISTEN));
 }
 
-bool DirectiveParser::parseReturnDirective(const std::vector<std::string>& tokens, size_t* pos, Return* returnValue) {
+bool DirectiveParser::parseReturnDirective(const std::vector<std::string>& tokens, std::size_t* pos, Return* returnValue) {
     if (!returnValue || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::RETURN));
         return false;
@@ -333,7 +333,7 @@ bool DirectiveParser::parseReturnDirective(const std::vector<std::string>& token
         throwConfigError("invalid number of arguments in \"" + std::string(config::directive::RETURN) + "\" directive");
     }
     std::string firstToken = tokens[(*pos)++];
-    size_t code;
+    std::size_t code;
     if (!stringToSizeT(firstToken, &code)) {
         throwConfigError("Invalid return code: \"" + firstToken + "\"");
     }
@@ -352,7 +352,7 @@ bool DirectiveParser::parseReturnDirective(const std::vector<std::string>& token
     return expectSemicolon(tokens, pos, std::string(config::directive::RETURN));
 }
 
-bool DirectiveParser::parseRootDirective(const std::vector<std::string>& tokens, size_t* pos, std::string* root) {
+bool DirectiveParser::parseRootDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::string* root) {
     if (!root || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::ROOT));
         return false;
@@ -365,7 +365,7 @@ bool DirectiveParser::parseRootDirective(const std::vector<std::string>& tokens,
     return expectSemicolon(tokens, pos, std::string(config::directive::ROOT));
 }
 
-bool DirectiveParser::parseServerNameDirective(const std::vector<std::string>& tokens, size_t* pos, std::vector<ServerName>* serverNames) {
+bool DirectiveParser::parseServerNameDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::vector<ServerName>* serverNames) {
     if (!serverNames || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::SERVER_NAME));
         return false;
@@ -378,7 +378,7 @@ bool DirectiveParser::parseServerNameDirective(const std::vector<std::string>& t
         names.push_back(tokens[*pos]);
         (*pos)++;
     }
-    for (size_t i = 0; i < names.size(); ++i) {
+    for (std::size_t i = 0; i < names.size(); ++i) {
         const std::string& name = names[i];
         ServerName serverName;
         if (name[0] == config::directive::ASTERISK[0]) {
@@ -396,7 +396,7 @@ bool DirectiveParser::parseServerNameDirective(const std::vector<std::string>& t
     return expectSemicolon(tokens, pos, std::string(config::directive::SERVER_NAME));
 }
 
-bool DirectiveParser::parseUploadStoreDirective(const std::vector<std::string>& tokens, size_t* pos, std::string* uploadStore) {
+bool DirectiveParser::parseUploadStoreDirective(const std::vector<std::string>& tokens, std::size_t* pos, std::string* uploadStore) {
     if (!uploadStore || *pos >= tokens.size()) {
         toolbox::logger::StepMark::error("Unexpected Error :" + std::string(config::directive::UPLOAD_STORE));
         return false;

--- a/src/config/config_directive_parser.cpp
+++ b/src/config/config_directive_parser.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <algorithm>
 #include <limits>
 #include <string>

--- a/src/config/config_http.cpp
+++ b/src/config/config_http.cpp
@@ -11,7 +11,7 @@ HttpConfig::HttpConfig() {
 }
 
 HttpConfig::HttpConfig(const HttpConfig& other) : ConfigBase(other) {
-    for (size_t i = 0; i < other._servers.size(); ++i) {
+    for (std::size_t i = 0; i < other._servers.size(); ++i) {
         toolbox::SharedPtr<ServerConfig> newServer(new ServerConfig(*other._servers[i].get()));
         _servers.push_back(newServer);
         _servers.back()->setHttpParent(this);

--- a/src/config/config_http.cpp
+++ b/src/config/config_http.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 

--- a/src/config/config_http.hpp
+++ b/src/config/config_http.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/config/config_http.hpp
+++ b/src/config/config_http.hpp
@@ -38,7 +38,7 @@ namespace config {
  * 
  * // Accessing the configured settings
  * const std::vector<toolbox::SharedPtr<ServerConfig> >& servers = httpConfig.getServers();
- * size_t serverCount = servers.size();  // Returns 2
+ * std::size_t serverCount = servers.size();  // Returns 2
  * @endcode
  */
 class HttpConfig : public ConfigBase {

--- a/src/config/config_inherit.cpp
+++ b/src/config/config_inherit.cpp
@@ -37,11 +37,11 @@ void serverEmptyCheck(ServerConfig* server) {
 
 void ConfigInherit::applyInheritance() {
     indexEmptyCheck(_httpConfig);
-    for (size_t i = 0; i < _httpConfig->getServers().size(); ++i) {
+    for (std::size_t i = 0; i < _httpConfig->getServers().size(); ++i) {
         ServerConfig* server = _httpConfig->getServers()[i].get();
         config::ConfigInherit::inheritHttpToServer(_httpConfig, server);
         serverEmptyCheck(server);
-        for (size_t j = 0; j < server->getLocations().size(); j++) {
+        for (std::size_t j = 0; j < server->getLocations().size(); j++) {
             LocationConfig* location = server->getLocations()[j].get();
             config::ConfigInherit::inheritServerToLocation(server, location);
             applyLocationInheritance(*location);
@@ -50,7 +50,7 @@ void ConfigInherit::applyInheritance() {
 }
 
 void ConfigInherit::applyLocationInheritance(LocationConfig& location) {
-    for (size_t i = 0; i < location.getLocations().size(); ++i) {
+    for (std::size_t i = 0; i < location.getLocations().size(); ++i) {
         LocationConfig* child = location.getLocations()[i].get();
         config::ConfigInherit::inheritLocationToLocation(&location, child);
         if (!child->getLocations().empty()) {
@@ -82,7 +82,7 @@ void ConfigInherit::inheritHttpToServer(const HttpConfig* http, ServerConfig* se
         server->setClientMaxBodySize(http->getClientMaxBodySize());
     }
     if (server->getErrorPages().empty() && !http->getErrorPages().empty()) {
-        for (size_t i = 0; i < http->getErrorPages().size(); ++i) {
+        for (std::size_t i = 0; i < http->getErrorPages().size(); ++i) {
             server->addErrorPage(http->getErrorPages()[i]);
         }
     }
@@ -122,7 +122,7 @@ void ConfigInherit::inheritServerToLocation(const ServerConfig* server, Location
         location->setClientMaxBodySize(server->getClientMaxBodySize());
     }
     if (location->getErrorPages().empty() && !server->getErrorPages().empty()) {
-        for (size_t i = 0; i < server->getErrorPages().size(); ++i) {
+        for (std::size_t i = 0; i < server->getErrorPages().size(); ++i) {
             location->addErrorPage(server->getErrorPages()[i]);
         }
     }
@@ -162,7 +162,7 @@ void ConfigInherit::inheritLocationToLocation(const LocationConfig* parent, Loca
         child->setClientMaxBodySize(parent->getClientMaxBodySize());
     }
     if (child->getErrorPages().empty() && !parent->getErrorPages().empty()) {
-        for (size_t i = 0; i < parent->getErrorPages().size(); ++i) {
+        for (std::size_t i = 0; i < parent->getErrorPages().size(); ++i) {
             child->addErrorPage(parent->getErrorPages()[i]);
         }
     }

--- a/src/config/config_inherit.cpp
+++ b/src/config/config_inherit.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include "config_inherit.hpp"
 #include "../../toolbox/stepmark.hpp"
 #include "../../toolbox/shared.hpp"

--- a/src/config/config_inherit.hpp
+++ b/src/config/config_inherit.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include "config_http.hpp"

--- a/src/config/config_lexer.cpp
+++ b/src/config/config_lexer.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 #include <cstring>

--- a/src/config/config_lexer.cpp
+++ b/src/config/config_lexer.cpp
@@ -24,20 +24,20 @@ bool isWhitespace(const char c) {
     return std::strchr(config::token::WHITESPACE_CHARS, c) != NULL;
 }
 
-void skipWhitespace(const std::string& input, size_t* pos) {
+void skipWhitespace(const std::string& input, std::size_t* pos) {
     while (*pos < input.length() && isWhitespace(input[*pos])) {
         (*pos)++;
     }
 }
 
-bool isNewline(const std::string& input, size_t pos) {
+bool isNewline(const std::string& input, std::size_t pos) {
     if (input[pos] == config::token::LF[0] || input[pos] == config::token::CR[0]) {
         return true;
     }
     return false;
 }
 
-void skipComment(const std::string& input, size_t* pos) {
+void skipComment(const std::string& input, std::size_t* pos) {
     while (*pos < input.length() && !isNewline(input, *pos)) {
         (*pos)++;
     }
@@ -46,7 +46,7 @@ void skipComment(const std::string& input, size_t* pos) {
     }
 }
 
-void processEscapeSequence(const std::string& input, size_t* pos, std::string* token) {
+void processEscapeSequence(const std::string& input, std::size_t* pos, std::string* token) {
     (*pos)++;
     switch (input[*pos]) {
         case 'n':
@@ -65,7 +65,7 @@ void processEscapeSequence(const std::string& input, size_t* pos, std::string* t
     (*pos)++;
 }
 
-void validateAfterQuotedString(const std::string& input, size_t pos) {
+void validateAfterQuotedString(const std::string& input, std::size_t pos) {
     if (pos < input.length()) {
         char ch = input[pos];
         if (!isWhitespace(ch) &&
@@ -79,7 +79,7 @@ void validateAfterQuotedString(const std::string& input, size_t pos) {
 }
 
 std::vector<std::string> ConfigLexer::tokenize(const std::string& input) {
-    size_t pos = 0;
+    std::size_t pos = 0;
     std::vector<std::string> tokens;
     std::string token;
     std::string preToken;
@@ -112,7 +112,7 @@ std::vector<std::string> ConfigLexer::tokenize(const std::string& input) {
     return tokens;
 }
 
-bool ConfigLexer::readToken(const std::string& input, size_t* pos, std::string* token) {
+bool ConfigLexer::readToken(const std::string& input, std::size_t* pos, std::string* token) {
     token->clear();
     if (input[*pos] == config::token::DOUBLE_QUOTE[0] ||
         input[*pos] == config::token::SINGLE_QUOTE[0]) {
@@ -131,7 +131,7 @@ bool ConfigLexer::readToken(const std::string& input, size_t* pos, std::string* 
     return true;
 }
 
-bool ConfigLexer::readQuotedString(const std::string& input, size_t* pos, std::string* token) {
+bool ConfigLexer::readQuotedString(const std::string& input, std::size_t* pos, std::string* token) {
     token->clear();
     char quote = input[*pos];
     (*pos)++;
@@ -153,9 +153,9 @@ bool ConfigLexer::readQuotedString(const std::string& input, size_t* pos, std::s
     return true;
 }
 
-bool ConfigLexer::readPlainToken(const std::string& input, size_t* pos, std::string* token) {
+bool ConfigLexer::readPlainToken(const std::string& input, std::size_t* pos, std::string* token) {
     token->clear();
-    size_t start = *pos;
+    std::size_t start = *pos;
     while (*pos < input.length() &&
             !isWhitespace(input[*pos]) &&
             input[*pos] != config::token::OPEN_BRACE[0] &&

--- a/src/config/config_lexer.hpp
+++ b/src/config/config_lexer.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/config/config_lexer.hpp
+++ b/src/config/config_lexer.hpp
@@ -16,9 +16,9 @@ class ConfigLexer {
  private:
     ConfigLexer(const ConfigLexer&);
     ConfigLexer& operator=(const ConfigLexer&);
-    bool readToken(const std::string& input, size_t* pos, std::string* token);
-    bool readPlainToken(const std::string& input, size_t* pos, std::string* token);
-    bool readQuotedString(const std::string& input, size_t* pos, std::string* token);
+    bool readToken(const std::string& input, std::size_t* pos, std::string* token);
+    bool readPlainToken(const std::string& input, std::size_t* pos, std::string* token);
+    bool readQuotedString(const std::string& input, std::size_t* pos, std::string* token);
 };
 
 }  // namespace config

--- a/src/config/config_location.cpp
+++ b/src/config/config_location.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 

--- a/src/config/config_location.cpp
+++ b/src/config/config_location.cpp
@@ -24,7 +24,7 @@ _path(other._path),
 _returnValue(other._returnValue),
 _parentServer(other._parentServer),
 _parentLocation(other._parentLocation) {
-    for (size_t i = 0; i < other._locations.size(); ++i) {
+    for (std::size_t i = 0; i < other._locations.size(); ++i) {
         toolbox::SharedPtr<LocationConfig> newLocation(new LocationConfig(*other._locations[i]));
         _locations.push_back(newLocation);
         _locations.back()->setLocationParent(this);
@@ -39,7 +39,7 @@ LocationConfig& LocationConfig::operator=(const LocationConfig& other) {
         _parentServer = other._parentServer;
         _parentLocation = other._parentLocation;
         _locations.clear();
-        for (size_t i = 0; i < other._locations.size(); ++i) {
+        for (std::size_t i = 0; i < other._locations.size(); ++i) {
             toolbox::SharedPtr<LocationConfig> newLocation(
                 new LocationConfig(*other._locations[i]));
             _locations.push_back(newLocation);

--- a/src/config/config_location.hpp
+++ b/src/config/config_location.hpp
@@ -55,7 +55,7 @@ class LocationConfig : public ConfigBase {
     const std::vector<toolbox::SharedPtr<LocationConfig> >& getLocations() const { return _locations; }
     void addLocation(const toolbox::SharedPtr<LocationConfig>& location) { _locations.push_back(location); }
     bool hasLocations() const { return !_locations.empty(); }
-    size_t getLocationsCount() const { return _locations.size(); }
+    std::size_t getLocationsCount() const { return _locations.size(); }
 
  private:
     std::string _path;

--- a/src/config/config_location.hpp
+++ b/src/config/config_location.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/config/config_namespace.cpp
+++ b/src/config/config_namespace.cpp
@@ -48,15 +48,15 @@ const char* SEMICOLON = ";";
 const char EQUAL = '=';
 const char* ON = "on";
 const char* OFF = "off";
-const size_t MIN_ERROR_PAGE_CODE = 300;
-const size_t MAX_ERROR_PAGE_CODE = 599;
-const size_t MIN_NEW_STATUS_CODE = 200;
-const size_t MAX_NEW_STATUS_CODE = 599;
+const std::size_t MIN_ERROR_PAGE_CODE = 300;
+const std::size_t MAX_ERROR_PAGE_CODE = 599;
+const std::size_t MIN_NEW_STATUS_CODE = 200;
+const std::size_t MAX_NEW_STATUS_CODE = 599;
 const char* ASTERISK = "*";
-const size_t MIN_PORT = 1;
-const size_t MAX_PORT = 65535;
+const std::size_t MIN_PORT = 1;
+const std::size_t MAX_PORT = 65535;
 const char* LISTEN_DEFAULT_SERVER = "default_server";
-const size_t MAX_RETURN_CODE = 999;
+const std::size_t MAX_RETURN_CODE = 999;
 }  // namespace directive
 
 namespace method {
@@ -64,12 +64,12 @@ const char* GET = "GET";
 const char* HEAD = "HEAD";
 const char* POST = "POST";
 const char* DELETE = "DELETE";
-const size_t ALLOWED_METHODS_COUNT = 4;
+const std::size_t ALLOWED_METHODS_COUNT = 4;
 const char* ALLOWED_METHODS[ALLOWED_METHODS_COUNT] = {GET, HEAD, POST, DELETE};
 }  // namespace method
 
 const bool DEFAULT_AUTOINDEX = false;
-const size_t DEFAULT_CLIENT_MAX_BODY_SIZE = 1024 * 1024;
+const std::size_t DEFAULT_CLIENT_MAX_BODY_SIZE = 1024 * 1024;
 const char* DEFAULT_CGI_PATH = "cgi";
 const char* DEFAULT_FILE = "conf/default.conf";
 const int DEFAULT_PORT = 80;
@@ -80,6 +80,6 @@ const char* DEFAULT_ROOT = "html";
 const char* DEFAULT_SERVER_NAME = "";
 const char* DEFAULT_UPLOAD_STORE = "upload";
 const char* DEFAULT_LOCATION_PATH = "/";
-const size_t CONF_BUFFER = 4096;
+const std::size_t CONF_BUFFER = 4096;
 
 }  // namespace config

--- a/src/config/config_namespace.cpp
+++ b/src/config/config_namespace.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 

--- a/src/config/config_namespace.hpp
+++ b/src/config/config_namespace.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/config/config_namespace.hpp
+++ b/src/config/config_namespace.hpp
@@ -46,15 +46,15 @@ extern const char* SEMICOLON;
 extern const char EQUAL;
 extern const char* ON;
 extern const char* OFF;
-extern const size_t MIN_ERROR_PAGE_CODE;
-extern const size_t MAX_ERROR_PAGE_CODE;
-extern const size_t MIN_NEW_STATUS_CODE;
-extern const size_t MAX_NEW_STATUS_CODE;
+extern const std::size_t MIN_ERROR_PAGE_CODE;
+extern const std::size_t MAX_ERROR_PAGE_CODE;
+extern const std::size_t MIN_NEW_STATUS_CODE;
+extern const std::size_t MAX_NEW_STATUS_CODE;
 extern const char* ASTERISK;
-extern const size_t MIN_PORT;
-extern const size_t MAX_PORT;
+extern const std::size_t MIN_PORT;
+extern const std::size_t MAX_PORT;
 extern const char* LISTEN_DEFAULT_SERVER;
-extern const size_t MAX_RETURN_CODE;
+extern const std::size_t MAX_RETURN_CODE;
 }  // namespace directive
 
 namespace method {
@@ -62,12 +62,12 @@ extern const char* GET;
 extern const char* HEAD;
 extern const char* POST;
 extern const char* DELETE;
-extern const size_t ALLOWED_METHODS_COUNT;
+extern const std::size_t ALLOWED_METHODS_COUNT;
 extern const char* ALLOWED_METHODS[];
 }  // namespace method
 
 extern const bool DEFAULT_AUTOINDEX;
-extern const size_t DEFAULT_CLIENT_MAX_BODY_SIZE;
+extern const std::size_t DEFAULT_CLIENT_MAX_BODY_SIZE;
 extern const char* DEFAULT_CGI_PATH;
 extern const char* DEFAULT_FILE;
 extern const int DEFAULT_PORT;
@@ -78,5 +78,5 @@ extern const char* DEFAULT_ROOT;
 extern const char* DEFAULT_SERVER_NAME;
 extern const char* DEFAULT_UPLOAD_STORE;
 extern const char* DEFAULT_LOCATION_PATH;
-extern const size_t CONF_BUFFER;
+extern const std::size_t CONF_BUFFER;
 }  // namespace config

--- a/src/config/config_parser.cpp
+++ b/src/config/config_parser.cpp
@@ -53,7 +53,7 @@ bool ConfigParser::readFile(const std::string& filepath) {
 
 bool ConfigParser::parse() {
     toolbox::logger::StepMark::info("Parsing configuration");
-    size_t pos = 0;
+    std::size_t pos = 0;
     if (_tokens.empty()) {
         return false;
     } else {
@@ -70,7 +70,7 @@ bool ConfigParser::parse() {
     return true;
 }
 
-void ConfigParser::validateBlockEnd(const std::vector<std::string>& tokens, size_t* pos) {
+void ConfigParser::validateBlockEnd(const std::vector<std::string>& tokens, std::size_t* pos) {
     if (*pos >= tokens.size() || tokens[*pos] != config::token::CLOSE_BRACE) {
         throwConfigError("unexpected end of file, expecting \"" + std::string(config::token::CLOSE_BRACE) + "\"");
     }

--- a/src/config/config_parser.cpp
+++ b/src/config/config_parser.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/src/config/config_parser.hpp
+++ b/src/config/config_parser.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/config/config_parser.hpp
+++ b/src/config/config_parser.hpp
@@ -19,7 +19,7 @@ class ConfigParser {
     ConfigParser();
     ~ConfigParser();
     toolbox::SharedPtr<HttpConfig> parseFile(const std::string& filepath);
-    size_t getTokenCount() const { return _tokens.size(); }
+    std::size_t getTokenCount() const { return _tokens.size(); }
 
  private:
     ConfigParser(const ConfigParser&);
@@ -27,16 +27,16 @@ class ConfigParser {
 
     bool readFile(const std::string& filepath);
     bool parse();
-    bool parseHttpBlock(const std::vector<std::string>& tokens, size_t* pos);
-    bool parseHttpDirectives(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* httpConfig);
-    bool parseServerBlock(const std::vector<std::string>& tokens, size_t* pos, config::ServerConfig* serverConfig);
-    bool parseServerDirectives(const std::vector<std::string>& tokens, size_t* pos, config::ServerConfig* serverConfig);
-    bool parseServerDirectiveContent(const std::vector<std::string>& tokens, size_t* pos, const std::string& directiveName);
-    bool parseLocationBlock(const std::vector<std::string>& tokens, size_t* pos, config::ServerConfig* serverConfig ,config::LocationConfig* locationConfig);
-    bool parseLocationDirectives(const std::vector<std::string>& tokens, size_t* pos, config::LocationConfig* locationConfig);
-    bool parseNestedLocationBlock(const std::vector<std::string>& tokens,  size_t* pos,  config::LocationConfig* parentLocation, config::LocationConfig* locationConfig);
-    bool handleNestedLocationBlock(const std::vector<std::string>& tokens, size_t* pos, config::LocationConfig* parentLocation);
-    void validateBlockEnd(const std::vector<std::string>& tokens, size_t* pos);
+    bool parseHttpBlock(const std::vector<std::string>& tokens, std::size_t* pos);
+    bool parseHttpDirectives(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* httpConfig);
+    bool parseServerBlock(const std::vector<std::string>& tokens, std::size_t* pos, config::ServerConfig* serverConfig);
+    bool parseServerDirectives(const std::vector<std::string>& tokens, std::size_t* pos, config::ServerConfig* serverConfig);
+    bool parseServerDirectiveContent(const std::vector<std::string>& tokens, std::size_t* pos, const std::string& directiveName);
+    bool parseLocationBlock(const std::vector<std::string>& tokens, std::size_t* pos, config::ServerConfig* serverConfig ,config::LocationConfig* locationConfig);
+    bool parseLocationDirectives(const std::vector<std::string>& tokens, std::size_t* pos, config::LocationConfig* locationConfig);
+    bool parseNestedLocationBlock(const std::vector<std::string>& tokens,  std::size_t* pos,  config::LocationConfig* parentLocation, config::LocationConfig* locationConfig);
+    bool handleNestedLocationBlock(const std::vector<std::string>& tokens, std::size_t* pos, config::LocationConfig* parentLocation);
+    void validateBlockEnd(const std::vector<std::string>& tokens, std::size_t* pos);
 
     std::string _input;
     std::vector<std::string> _tokens;

--- a/src/config/config_parser_http.cpp
+++ b/src/config/config_parser_http.cpp
@@ -10,7 +10,7 @@
 
 namespace config {
 
-void validateHttpBlockStart(const std::vector<std::string>& tokens, size_t* pos, const std::string& expectedDirective) {
+void validateHttpBlockStart(const std::vector<std::string>& tokens, std::size_t* pos, const std::string& expectedDirective) {
     if (*pos >= tokens.size() || tokens[*pos] != expectedDirective) {
         if (isContextToken(tokens[*pos]) || isDirectiveToken(tokens[*pos])) {
             throwConfigError("\"" + std::string(tokens[*pos]) + "\" directive is not allowed here");
@@ -25,7 +25,7 @@ void validateHttpBlockStart(const std::vector<std::string>& tokens, size_t* pos,
     (*pos)++;
 }
 
-bool ConfigParser::parseHttpBlock(const std::vector<std::string>& tokens, size_t* pos) {
+bool ConfigParser::parseHttpBlock(const std::vector<std::string>& tokens, std::size_t* pos) {
     validateHttpBlockStart(tokens, pos, config::context::HTTP);
     if (!parseHttpDirectives(tokens, pos, _config.get())) {
         return false;
@@ -34,7 +34,7 @@ bool ConfigParser::parseHttpBlock(const std::vector<std::string>& tokens, size_t
     return true;
 }
 
-bool ConfigParser::parseHttpDirectives(const std::vector<std::string>& tokens, size_t* pos, config::HttpConfig* config) {
+bool ConfigParser::parseHttpDirectives(const std::vector<std::string>& tokens, std::size_t* pos, config::HttpConfig* config) {
     std::map<std::string, bool> processedDirectives;
     while (*pos < tokens.size() && tokens[*pos] != config::token::CLOSE_BRACE) {
         std::string directiveName = tokens[*pos];

--- a/src/config/config_parser_http.cpp
+++ b/src/config/config_parser_http.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <vector>
 
 #include "config_parser.hpp"

--- a/src/config/config_parser_location.cpp
+++ b/src/config/config_parser_location.cpp
@@ -11,7 +11,7 @@ namespace config {
 
 void locationPathDuplicateCheck(const std::string& path, const config::ServerConfig& serverConfig) {
     const std::vector<toolbox::SharedPtr<config::LocationConfig> >& locations = serverConfig.getLocations();
-    for (size_t i = 0; i < locations.size(); ++i) {
+    for (std::size_t i = 0; i < locations.size(); ++i) {
         if (path == locations[i]->getPath()) {
             throwConfigError("duplicate location \""  + path + "\"" );
         }
@@ -20,14 +20,14 @@ void locationPathDuplicateCheck(const std::string& path, const config::ServerCon
 
 void nestLocationPathDuplicateCheck(const std::string& path, const config::LocationConfig& parentConfig) {
     const std::vector<toolbox::SharedPtr<config::LocationConfig> >& locations = parentConfig.getLocations();
-    for (size_t i = 0; i < locations.size(); ++i) {
+    for (std::size_t i = 0; i < locations.size(); ++i) {
         if (path == locations[i]->getPath()) {
             throwConfigError("duplicate location \""  + path + "\"");
         }
     }
 }
 
-void validateAndParseLocationBlockStart(const std::vector<std::string>& tokens, size_t* pos, config::ServerConfig* serverConfig ,config::LocationConfig* locationConfig) {
+void validateAndParseLocationBlockStart(const std::vector<std::string>& tokens, std::size_t* pos, config::ServerConfig* serverConfig ,config::LocationConfig* locationConfig) {
     if (*pos >= tokens.size() || tokens[*pos] != config::context::LOCATION) {
         if (isContextToken(tokens[*pos])) {
             throwConfigError("\"" + std::string(tokens[*pos]) + "\" directive is not allowed here");
@@ -48,7 +48,7 @@ void validateAndParseLocationBlockStart(const std::vector<std::string>& tokens, 
     (*pos)++;
 }
 
-void validateAndParseNestedLocationBlockStart(const std::vector<std::string>& tokens, size_t* pos, config::LocationConfig* parentConfig, config::LocationConfig* childConfig) {
+void validateAndParseNestedLocationBlockStart(const std::vector<std::string>& tokens, std::size_t* pos, config::LocationConfig* parentConfig, config::LocationConfig* childConfig) {
     if (*pos >= tokens.size() || tokens[*pos] != config::context::LOCATION) {
         if (isContextToken(tokens[*pos])) {
             throwConfigError("\"" + std::string(tokens[*pos]) + "\" directive is not allowed here");
@@ -72,7 +72,7 @@ void validateAndParseNestedLocationBlockStart(const std::vector<std::string>& to
     (*pos)++;
 }
 
-bool ConfigParser::parseLocationBlock(const std::vector<std::string>& tokens, size_t* pos, config::ServerConfig* serverConfig, config::LocationConfig* locationConfig) {
+bool ConfigParser::parseLocationBlock(const std::vector<std::string>& tokens, std::size_t* pos, config::ServerConfig* serverConfig, config::LocationConfig* locationConfig) {
     validateAndParseLocationBlockStart(tokens, pos, serverConfig, locationConfig);
     if (!parseLocationDirectives(tokens, pos, locationConfig)) {
         return false;
@@ -82,7 +82,7 @@ bool ConfigParser::parseLocationBlock(const std::vector<std::string>& tokens, si
     return true;
 }
 
-bool ConfigParser::parseNestedLocationBlock(const std::vector<std::string>& tokens,  size_t* pos,  config::LocationConfig* parentConfig, config::LocationConfig* childConfig) {
+bool ConfigParser::parseNestedLocationBlock(const std::vector<std::string>& tokens,  std::size_t* pos,  config::LocationConfig* parentConfig, config::LocationConfig* childConfig) {
     validateAndParseNestedLocationBlockStart(tokens, pos, parentConfig, childConfig);
     if (!parseLocationDirectives(tokens, pos, childConfig)) {
         return false;
@@ -92,7 +92,7 @@ bool ConfigParser::parseNestedLocationBlock(const std::vector<std::string>& toke
     return true;
 }
 
-bool ConfigParser::parseLocationDirectives(const std::vector<std::string>& tokens, size_t* pos, config::LocationConfig* locationConfig) {
+bool ConfigParser::parseLocationDirectives(const std::vector<std::string>& tokens, std::size_t* pos, config::LocationConfig* locationConfig) {
     std::map<std::string, bool> processedDirectives;
     while (*pos < tokens.size() && tokens[*pos] != config::token::CLOSE_BRACE) {
         std::string directiveName = tokens[*pos];
@@ -130,7 +130,7 @@ bool ConfigParser::parseLocationDirectives(const std::vector<std::string>& token
     return true;
 }
 
-bool ConfigParser::handleNestedLocationBlock(const std::vector<std::string>& tokens, size_t* pos, config::LocationConfig* parentLocation) {
+bool ConfigParser::handleNestedLocationBlock(const std::vector<std::string>& tokens, std::size_t* pos, config::LocationConfig* parentLocation) {
     toolbox::SharedPtr<config::LocationConfig> nestedLocation(new config::LocationConfig());
     if (!parseNestedLocationBlock(tokens, pos, parentLocation, nestedLocation.get())) {
         return false;

--- a/src/config/config_parser_location.cpp
+++ b/src/config/config_parser_location.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include "config_parser.hpp"
 #include "config_namespace.hpp"
 #include "config_location.hpp"

--- a/src/config/config_parser_server.cpp
+++ b/src/config/config_parser_server.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include "config_parser.hpp"
 #include "config_namespace.hpp"
 #include "config_server.hpp"

--- a/src/config/config_parser_server.cpp
+++ b/src/config/config_parser_server.cpp
@@ -8,7 +8,7 @@
 
 namespace config {
 
-void validateServerBlockStart(const std::vector<std::string>& tokens, size_t* pos, const std::string& expectedDirective) {
+void validateServerBlockStart(const std::vector<std::string>& tokens, std::size_t* pos, const std::string& expectedDirective) {
     if (*pos >= tokens.size() || tokens[*pos] != expectedDirective) {
         if (isContextToken(tokens[*pos])) {
             throwConfigError("\"" + std::string(tokens[*pos]) + "\" directive is not allowed here");
@@ -23,7 +23,7 @@ void validateServerBlockStart(const std::vector<std::string>& tokens, size_t* po
     (*pos)++;
 }
 
-bool ConfigParser::parseServerBlock(const std::vector<std::string>& tokens, size_t* pos, config::ServerConfig* serverConfig) {
+bool ConfigParser::parseServerBlock(const std::vector<std::string>& tokens, std::size_t* pos, config::ServerConfig* serverConfig) {
     validateServerBlockStart(tokens, pos, config::context::SERVER);
     if (!parseServerDirectives(tokens, pos, serverConfig)) {
         return false;
@@ -33,9 +33,9 @@ bool ConfigParser::parseServerBlock(const std::vector<std::string>& tokens, size
     return true;
 }
 
-bool ConfigParser::parseServerDirectives(const std::vector<std::string>& tokens, size_t* pos, config::ServerConfig* serverConfig) {
+bool ConfigParser::parseServerDirectives(const std::vector<std::string>& tokens, std::size_t* pos, config::ServerConfig* serverConfig) {
     std::map<std::string, bool> processedDirectives;
-    size_t locationCounter = 0;
+    std::size_t locationCounter = 0;
     while (*pos < tokens.size() && tokens[*pos] != config::token::CLOSE_BRACE) {
         std::string directiveName = tokens[*pos];
         (*pos)++;

--- a/src/config/config_server.cpp
+++ b/src/config/config_server.cpp
@@ -24,7 +24,7 @@ _listens(other._listens),
 _serverNames(other._serverNames),
 _returnValue(other._returnValue),
 _parent(other._parent) {
-    for (size_t i = 0; i < other._locations.size(); ++i) {
+    for (std::size_t i = 0; i < other._locations.size(); ++i) {
         toolbox::SharedPtr<LocationConfig> newLocation(new LocationConfig(*other._locations[i]));
         _locations.push_back(newLocation);
         _locations.back()->setServerParent(this);

--- a/src/config/config_server.cpp
+++ b/src/config/config_server.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 

--- a/src/config/config_server.hpp
+++ b/src/config/config_server.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/config/config_server.hpp
+++ b/src/config/config_server.hpp
@@ -60,7 +60,7 @@ class ServerConfig : public ConfigBase {
     const std::vector<toolbox::SharedPtr<LocationConfig> >& getLocations() const { return _locations; }
     void addLocation(const toolbox::SharedPtr<LocationConfig>& location) { _locations.push_back(location); }
     bool hasLocations() const { return !_locations.empty(); }
-    size_t getLocationsCount() const { return _locations.size(); }
+    std::size_t getLocationsCount() const { return _locations.size(); }
 
  private:
     ServerConfig& operator=(const ServerConfig&);

--- a/src/config/config_util.cpp
+++ b/src/config/config_util.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <limits>
 #include <algorithm>

--- a/src/config/config_util.cpp
+++ b/src/config/config_util.cpp
@@ -16,7 +16,7 @@ bool isCaseInsensitiveIdentical(const std::string& str1, const std::string& str2
     if (str1.size() != str2.size()) {
         return false;
     }
-    for (size_t i = 0; i < str1.size(); ++i) {
+    for (std::size_t i = 0; i < str1.size(); ++i) {
         char c1 = std::tolower(static_cast<unsigned char>(str1[i]));
         char c2 = std::tolower(static_cast<unsigned char>(str2[i]));
         if (c1 != c2) {
@@ -26,7 +26,7 @@ bool isCaseInsensitiveIdentical(const std::string& str1, const std::string& str2
     return true;
 }
 
-bool stringToSizeT(const std::string& str, size_t* result) {
+bool stringToSizeT(const std::string& str, std::size_t* result) {
     if (!result) {
         toolbox::logger::StepMark::error("Invalid result pointer");
         return false;
@@ -36,17 +36,17 @@ bool stringToSizeT(const std::string& str, size_t* result) {
         return false;
     }
     // off_t is max
-    const size_t max_value = std::numeric_limits<off_t>::max();
-    const size_t cutoff = max_value / 10;
-    const size_t cutlim = max_value % 10;
-    size_t value = 0;
-    for (size_t i = 0; i < str.size(); i++) {
+    const std::size_t max_value = std::numeric_limits<off_t>::max();
+    const std::size_t cutoff = max_value / 10;
+    const std::size_t cutlim = max_value % 10;
+    std::size_t value = 0;
+    for (std::size_t i = 0; i < str.size(); i++) {
         char c = str[i];
         if (!std::isdigit(c)) {
             toolbox::logger::StepMark::debug("Invalid character in numeric value: " + str);
             return false;
         }
-        if (value > cutoff || (value == cutoff && static_cast<size_t>(c - '0') > cutlim)) {
+        if (value > cutoff || (value == cutoff && static_cast<std::size_t>(c - '0') > cutlim)) {
             toolbox::logger::StepMark::error("Numeric value too large: " + str);
             return false;
         }
@@ -60,8 +60,8 @@ int pathCmp(const std::string& s1, const std::string& s2) {
     if (s1.length() > s2.length()) {
         return 0;
     }
-    size_t n = s1.length();
-    for (size_t i = 0; i < n; ++i) {
+    std::size_t n = s1.length();
+    for (std::size_t i = 0; i < n; ++i) {
         char c1 = s1[i];
         char c2 = s2[i];
         if (c1 == c2) {
@@ -80,8 +80,8 @@ void throwConfigError(const std::string& message) {
     throw ConfigException(message);
 }
 
-bool isInAllowedTokens(const std::string& token, const std::string allowedTokens[], size_t tokenCount) {
-    for (size_t i = 0; i < tokenCount; i++) {
+bool isInAllowedTokens(const std::string& token, const std::string allowedTokens[], std::size_t tokenCount) {
+    for (std::size_t i = 0; i < tokenCount; i++) {
         if (token == allowedTokens[i]) {
             return true;
         }
@@ -95,7 +95,7 @@ bool isContextToken(const std::string& token) {
         config::context::SERVER,
         config::context::LOCATION
     };
-    const size_t contextCount = sizeof(contexts) / sizeof(contexts[0]);
+    const std::size_t contextCount = sizeof(contexts) / sizeof(contexts[0]);
     return isInAllowedTokens(token, contexts, contextCount);
 }
 
@@ -114,7 +114,7 @@ bool isDirectiveToken(const std::string& token) {
         config::directive::SERVER_NAME,
         config::directive::UPLOAD_STORE
     };
-    const size_t directiveCount = sizeof(directives) / sizeof(directives[0]);
+    const std::size_t directiveCount = sizeof(directives) / sizeof(directives[0]);
     return isInAllowedTokens(token, directives, directiveCount);
 }
 

--- a/src/config/config_util.hpp
+++ b/src/config/config_util.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/config/config_util.hpp
+++ b/src/config/config_util.hpp
@@ -6,7 +6,7 @@
 namespace config {
 
 bool isCaseInsensitiveIdentical(const std::string& str1, const std::string& str2);
-bool stringToSizeT(const std::string& str, size_t* result);
+bool stringToSizeT(const std::string& str, std::size_t* result);
 int pathCmp(const std::string& s1, const std::string& s2);
 void throwConfigError(const std::string& message);
 bool isContextToken(const std::string& token);

--- a/src/core/client.cpp
+++ b/src/core/client.cpp
@@ -78,7 +78,7 @@ std::string Client::getServerIp() const {
     return "";
 }
 
-size_t Client::getServerPort() const {
+std::size_t Client::getServerPort() const {
     struct sockaddr_in addr;
     socklen_t addr_len = sizeof(addr);
     if (getsockname(_socket_fd,

--- a/src/core/client.hpp
+++ b/src/core/client.hpp
@@ -37,7 +37,7 @@ class Client {
     int getFd() const;
     std::string getIp() const;
     std::string getServerIp() const;
-    size_t getServerPort() const;
+    std::size_t getServerPort() const;
     void setLastAccessTime();
 
     toolbox::SharedPtr<http::Request> getRequest() const;

--- a/src/core/constant.hpp
+++ b/src/core/constant.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <cstddef>

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <fcntl.h>
@@ -5,7 +7,6 @@
 #include <unistd.h>
 #include <string>
 #include <iostream>
-#include <cerrno>
 #include <cstdio>
 #include <sstream>
 #include <cstring>

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -38,10 +38,10 @@ int main(int argc, char* argv[]) {
                                         config::Config::getHttpConfig();
         std::vector<toolbox::SharedPtr<Server> > servers;
         std::set<std::pair<std::string, int> > boundAddresses;
-        for (size_t i = 0; i < httpConfig->getServers().size(); ++i) {
+        for (std::size_t i = 0; i < httpConfig->getServers().size(); ++i) {
             toolbox::SharedPtr<config::ServerConfig> serverConfig =
                                                     httpConfig->getServers()[i];
-            for (size_t j = 0; j < serverConfig->getListens().size(); ++j) {
+            for (std::size_t j = 0; j < serverConfig->getListens().size(); ++j) {
                 int port = serverConfig->getListens()[j].getPort();
                 std::string ip = serverConfig->getListens()[j].getIp();
                 std::pair<std::string, int> address(ip, port);
@@ -108,7 +108,7 @@ int main(int argc, char* argv[]) {
                 toolbox::logger::StepMark::error("Main: whileloop: " + std::string(e.what()));
             }
         }
-        for (size_t i = 0; i < servers.size(); ++i) {
+        for (std::size_t i = 0; i < servers.size(); ++i) {
             Epoll::del(servers[i]->getFd());
         }
     } catch (std::exception& e) {

--- a/src/core/server.cpp
+++ b/src/core/server.cpp
@@ -90,9 +90,9 @@ uint32_t Server::parseIpAddress(const std::string& ip) const {
     if (ip == "0.0.0.0") {
         return INADDR_ANY;
     }
-    size_t pos1 = ip.find('.');
-    size_t pos2 = ip.find('.', pos1 + 1);
-    size_t pos3 = ip.find('.', pos2 + 1);
+    std::size_t pos1 = ip.find('.');
+    std::size_t pos2 = ip.find('.', pos1 + 1);
+    std::size_t pos3 = ip.find('.', pos2 + 1);
     if (pos1 == std::string::npos ||
         pos2 == std::string::npos ||
         pos3 == std::string::npos) {

--- a/src/core/server.hpp
+++ b/src/core/server.hpp
@@ -1,4 +1,5 @@
 // Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <fcntl.h>

--- a/src/http/case_insensitive_less.hpp
+++ b/src/http/case_insensitive_less.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/cgi/cgi_execute.cpp
+++ b/src/http/cgi/cgi_execute.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <cstring>
 #include <iostream>
 #include <cstdlib>

--- a/src/http/cgi/cgi_execute.cpp
+++ b/src/http/cgi/cgi_execute.cpp
@@ -144,7 +144,7 @@ void CgiExecute::setServerVariables(const HTTPRequest& request,
     } else {
         _environment[http::cgi::meta::SERVER_NAME] = hostValues.front();
     }
-    size_t serverPort = client->getServerPort();
+    std::size_t serverPort = client->getServerPort();
     if (serverPort == 0) {
         _environment[http::cgi::meta::SERVER_PORT] = "";
     } else {
@@ -225,7 +225,7 @@ void CgiExecute::convertHeadersToEnv(const HTTPRequest& request) {
             continue;
         }
         std::string envName = http::cgi::ENV_PREFIX;
-        for (size_t i = 0; i < name.size(); i++) {
+        for (std::size_t i = 0; i < name.size(); i++) {
             char c = name[i];
             if (c == '-') {
                 envName += '_';
@@ -352,7 +352,7 @@ std::vector<char*> CgiExecute::prepareEnvironmentVariables() {
         _envStrings.push_back(it->first + "=" + it->second);
     }
     std::vector<char*> envp;
-    for (size_t i = 0; i < _envStrings.size(); ++i) {
+    for (std::size_t i = 0; i < _envStrings.size(); ++i) {
         envp.push_back(const_cast<char*>(_envStrings[i].c_str()));
     }
     envp.push_back(NULL);
@@ -449,14 +449,13 @@ bool CgiExecute::continueWriteRequestBody() {
     if (_lastWriteTime != 0 && (currentTime - _lastWriteTime) < 1) {
         return false;
     }
-    size_t remaining = _totalBytes - _bytesWritten;
-    size_t writeSize = remaining;
+    std::size_t remaining = _totalBytes - _bytesWritten;
+    std::size_t writeSize = remaining;
     if (writeSize > core::IO_BUFFER_SIZE) {
         writeSize = core::IO_BUFFER_SIZE;
     }
-    ssize_t written = write(_inputPipe[1],
-                            _writeBuffer.c_str() + _bytesWritten,
-                            writeSize);
+    ssize_t written =
+        write(_inputPipe[1], _writeBuffer.c_str() + _bytesWritten, writeSize);
     toolbox::logger::StepMark::info(
         "continueWriteRequestBody: write returned "
         + toolbox::to_string(written) + " bytes");
@@ -530,7 +529,7 @@ bool CgiExecute::continueReadOutput() {
     }
 }
 
-bool CgiExecute::processReadBytes(const char* buffer, size_t bytes) {
+bool CgiExecute::processReadBytes(const char* buffer, std::size_t bytes) {
     BaseParser::ParseStatus status = _parser.run(std::string(buffer, bytes));
     if (status == BaseParser::P_COMPLETED) {
         _readState = READ_COMPLETED;
@@ -671,13 +670,13 @@ bool CgiExecute::setNonBlocking(int fd) {
 std::string CgiExecute::extractScriptName(const std::string& requestPath,
                                         const std::string& scriptPath) const {
     std::string filename;
-    size_t scriptLastSlash = scriptPath.find_last_of('/');
+    std::size_t scriptLastSlash = scriptPath.find_last_of('/');
     if (scriptLastSlash != std::string::npos) {
         filename = scriptPath.substr(scriptLastSlash + 1);
     } else {
         filename = scriptPath;
     }
-    size_t pos = requestPath.find(filename);
+    std::size_t pos = requestPath.find(filename);
     if (pos != std::string::npos) {
         return requestPath.substr(0, pos + filename.length());
     }

--- a/src/http/cgi/cgi_execute.hpp
+++ b/src/http/cgi/cgi_execute.hpp
@@ -68,7 +68,7 @@ class CgiExecute {
     CgiExecute(const CgiExecute& other);
     CgiExecute& operator=(const CgiExecute& other);
 
-    bool processReadBytes(const char* buffer, size_t bytes);
+    bool processReadBytes(const char* buffer, std::size_t bytes);
     bool processEndOfFile();
     bool handleReadError();
 
@@ -121,8 +121,8 @@ class CgiExecute {
     bool _isExecveError;
     std::vector<std::string> _envStrings;
     WriteState _writeState;
-    size_t _totalBytes;
-    size_t _bytesWritten;
+    std::size_t _totalBytes;
+    std::size_t _bytesWritten;
     std::string _writeBuffer;
     ReadState _readState;
     CgiResponseParser _parser;

--- a/src/http/cgi/cgi_execute.hpp
+++ b/src/http/cgi/cgi_execute.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/cgi/cgi_field_parser.cpp
+++ b/src/http/cgi/cgi_field_parser.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 
 #include "cgi_field_parser.hpp"

--- a/src/http/cgi/cgi_field_parser.hpp
+++ b/src/http/cgi/cgi_field_parser.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/cgi/cgi_handler.cpp
+++ b/src/http/cgi/cgi_handler.cpp
@@ -310,7 +310,7 @@ CgiHandler::extractRedirectInfo(const CgiResponse& cgiResponse) {
 IOPendingState CgiHandler::executeInternalRequest(
                             const std::string& location,
                             const std::string& host,
-                            size_t redirectCount) {
+                            std::size_t redirectCount) {
     toolbox::SharedPtr<http::Request> clientRequest = _client->getRequest();
     clientRequest->setRedirectCount(redirectCount);
     clientRequest->setLocalRedirectInfo(http::method::GET, location, host);
@@ -328,14 +328,14 @@ bool CgiHandler::validateParameters(const std::string& scriptPath,
         return false;
     }
     std::string fileName;
-    size_t lastSlash = scriptPath.find_last_of('/');
+    std::size_t lastSlash = scriptPath.find_last_of('/');
     if (lastSlash != std::string::npos) {
         fileName = scriptPath.substr(lastSlash + 1);
     } else {
         fileName = scriptPath;
     }
     std::string fileExtension;
-    size_t lastDot = fileName.find_last_of('.');
+    std::size_t lastDot = fileName.find_last_of('.');
     if (lastDot != std::string::npos) {
         fileExtension = fileName.substr(lastDot);
     } else {
@@ -345,7 +345,7 @@ bool CgiHandler::validateParameters(const std::string& scriptPath,
         return false;
     }
     bool isValidExtension = false;
-    for (size_t i = 0; i < cgi_extension.size(); ++i) {
+    for (std::size_t i = 0; i < cgi_extension.size(); ++i) {
         if (fileExtension == cgi_extension[i]) {
             isValidExtension = true;
             break;

--- a/src/http/cgi/cgi_handler.cpp
+++ b/src/http/cgi/cgi_handler.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <iostream>
 #include <vector>
 #include <string>

--- a/src/http/cgi/cgi_handler.hpp
+++ b/src/http/cgi/cgi_handler.hpp
@@ -31,7 +31,7 @@ class CgiHandler {
                        const Client* client,
                        const config::LocationConfig& config,
                        const http::IOPendingState ioPendingState);
-    void setRedirectCount(size_t count) { _redirectCount = count; }
+    void setRedirectCount(std::size_t count) { _redirectCount = count; }
     void reset();
 
  private:
@@ -60,14 +60,14 @@ class CgiHandler {
     IOPendingState executeInternalRequest(
                      const std::string& location,
                      const std::string& host,
-                     size_t redirectCount);
+                     std::size_t redirectCount);
     void copyCgiResponseToResponse(const CgiResponse& cgiResponse,
                             Response& response);
     std::string buildScriptPath(const std::string& root,
                                const std::string& uriPath,
                                const std::vector<std::string>& cgiExtensions) const;
     CgiExecute _execute;
-    size_t _redirectCount;
+    std::size_t _redirectCount;
     const Client* _client;
 };
 

--- a/src/http/cgi/cgi_handler.hpp
+++ b/src/http/cgi/cgi_handler.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/cgi/cgi_response.cpp
+++ b/src/http/cgi/cgi_response.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <iostream>
 

--- a/src/http/cgi/cgi_response.hpp
+++ b/src/http/cgi/cgi_response.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/cgi/cgi_response_parser.cpp
+++ b/src/http/cgi/cgi_response_parser.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 
 #include "cgi_response_parser.hpp"

--- a/src/http/cgi/cgi_response_parser.hpp
+++ b/src/http/cgi/cgi_response_parser.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/get_gmt.cpp
+++ b/src/http/get_gmt.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include "get_gmt.hpp"
 
 #include <string>

--- a/src/http/get_gmt.hpp
+++ b/src/http/get_gmt.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/http_namespace.cpp
+++ b/src/http/http_namespace.cpp
@@ -77,10 +77,10 @@ const std::size_t CRLF_SIZE = 2;
 }  // namespace symbols
 
 namespace cgi {
-const size_t MAX_REDIRECTS = 10;
-const size_t TIMEOUT = 30;
-const size_t READ_BUFFER_SIZE = 4096;
-const size_t READ_TIMEOUT_SEC = 1;
+const std::size_t MAX_REDIRECTS = 10;
+const std::size_t TIMEOUT = 30;
+const std::size_t READ_BUFFER_SIZE = 4096;
+const std::size_t READ_TIMEOUT_SEC = 1;
 const char* GATEWAY_INTERFACE = "CGI/1.1";
 const char* SERVER_SOFTWARE = "WebServ-Ideal Broccoli/1.0";
 const char* ENV_PREFIX = "HTTP_";

--- a/src/http/http_namespace.cpp
+++ b/src/http/http_namespace.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include "http_namespace.hpp"
 
 namespace http {

--- a/src/http/http_namespace.hpp
+++ b/src/http/http_namespace.hpp
@@ -73,10 +73,10 @@ extern const std::size_t CRLF_SIZE;
 }  // namespace symbols
 
 namespace cgi {
-extern const size_t MAX_REDIRECTS;
-extern const size_t TIMEOUT;
-extern const size_t READ_BUFFER_SIZE;
-extern const size_t READ_TIMEOUT_SEC;
+extern const std::size_t MAX_REDIRECTS;
+extern const std::size_t TIMEOUT;
+extern const std::size_t READ_BUFFER_SIZE;
+extern const std::size_t READ_TIMEOUT_SEC;
 extern const char* GATEWAY_INTERFACE;
 extern const char* SERVER_SOFTWARE;
 extern const char* ENV_PREFIX;

--- a/src/http/http_namespace.hpp
+++ b/src/http/http_namespace.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/http_status.hpp
+++ b/src/http/http_status.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 namespace http {

--- a/src/http/parsing/base_field_parser.cpp
+++ b/src/http/parsing/base_field_parser.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 
 #include "base_field_parser.hpp"

--- a/src/http/parsing/base_field_parser.hpp
+++ b/src/http/parsing/base_field_parser.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/parsing/base_parser.cpp
+++ b/src/http/parsing/base_parser.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 
 #include "base_parser.hpp"

--- a/src/http/parsing/base_parser.hpp
+++ b/src/http/parsing/base_parser.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/parsing/field_validator.cpp
+++ b/src/http/parsing/field_validator.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <cstdlib>
 

--- a/src/http/parsing/field_validator.hpp
+++ b/src/http/parsing/field_validator.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include<string>

--- a/src/http/request/handleRequest.cpp
+++ b/src/http/request/handleRequest.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 #include <algorithm>

--- a/src/http/request/http_fields.cpp
+++ b/src/http/request/http_fields.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <utility>
 

--- a/src/http/request/http_fields.hpp
+++ b/src/http/request/http_fields.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <map>

--- a/src/http/request/http_request.hpp
+++ b/src/http/request/http_request.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <map>

--- a/src/http/request/io_pending_state.hpp
+++ b/src/http/request/io_pending_state.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 namespace http {

--- a/src/http/request/recv_request.cpp
+++ b/src/http/request/recv_request.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <limits>
 

--- a/src/http/request/request.cpp
+++ b/src/http/request/request.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include "request.hpp"
 #include "io_pending_state.hpp"
 

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -87,7 +87,7 @@ class Request {
      * for this request, which is important for handling local redirects.
      * @param count The number of redirects to set.
      */
-    void setRedirectCount(size_t count);
+    void setRedirectCount(std::size_t count);
 
     bool isErrorInternalRedirect() const;
     void setErrorInternalRedirect();
@@ -127,17 +127,18 @@ class Request {
         const std::vector<toolbox::SharedPtr<config::ServerConfig> >& servers,
         const std::string& hostName);
     bool processReturn(const config::Return& returnValue);
-    void processReturnWithContent(size_t statusCode,
-                                const std::string& content);
-    void processReturnWithoutContent(size_t statusCode);
-    bool isRedirectStatus(size_t statusCode) const;
-    bool hasDefaultErrorPage(size_t statusCode) const;
-    bool isMinimalResponse(size_t statusCode) const;
-    void setRedirectResponse(size_t statusCode, const std::string& location);
+    void processReturnWithContent(std::size_t statusCode,
+                                  const std::string& content);
+    void processReturnWithoutContent(std::size_t statusCode);
+    bool isRedirectStatus(std::size_t statusCode) const;
+    bool hasDefaultErrorPage(std::size_t statusCode) const;
+    bool isMinimalResponse(std::size_t statusCode) const;
+    void setRedirectResponse(std::size_t statusCode,
+                             const std::string& location);
     void setTextResponse(const std::string& content);
-    void setHtmlErrorResponse(size_t statusCode);
+    void setHtmlErrorResponse(std::size_t statusCode);
     void setEmptyTextResponse();
-    std::string generateDefaultBody(size_t statusCode);
+    std::string generateDefaultBody(std::size_t statusCode);
     bool selectLocation(
         const toolbox::SharedPtr<config::ServerConfig>& server);
     toolbox::SharedPtr<config::LocationConfig> findDeepestMatchingLocation(

--- a/src/http/request/request.hpp
+++ b/src/http/request/request.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <vector>

--- a/src/http/request/request_field_parser.cpp
+++ b/src/http/request/request_field_parser.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 
 #include "request_field_parser.hpp"

--- a/src/http/request/request_field_parser.hpp
+++ b/src/http/request/request_field_parser.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/request/request_impl_basic.cpp
+++ b/src/http/request/request_impl_basic.cpp
@@ -26,7 +26,7 @@ http::Response http::Request::getResponse() const {
     return _response;
 }
 
-void http::Request::setRedirectCount(size_t count) {
+void http::Request::setRedirectCount(std::size_t count) {
     _requestDepth = count;
     _cgiHandler.setRedirectCount(count);
 }

--- a/src/http/request/request_impl_basic.cpp
+++ b/src/http/request/request_impl_basic.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include "request.hpp"
 

--- a/src/http/request/request_impl_config.cpp
+++ b/src/http/request/request_impl_config.cpp
@@ -52,9 +52,9 @@ toolbox::SharedPtr<config::ServerConfig> Request::selectServer() {
 bool Request::extractCandidateServers(
     const std::vector<toolbox::SharedPtr<config::ServerConfig> >& servers,
     std::vector<toolbox::SharedPtr<config::ServerConfig> >& candidateServers) {
-    for (size_t i = 0; i < servers.size(); ++i) {
+    for (std::size_t i = 0; i < servers.size(); ++i) {
         const std::vector<config::Listen>& listens = servers[i]->getListens();
-        for (size_t j = 0; j < listens.size(); ++j) {
+        for (std::size_t j = 0; j < listens.size(); ++j) {
             if (listens[j].getPort() == _client->getServerPort()) {
                 if (listens[j].getIp() ==  _client->getServerIp()) {
                     candidateServers.push_back(servers[i]);
@@ -84,10 +84,10 @@ std::string Request::extractHostName() {
 toolbox::SharedPtr<config::ServerConfig> Request::matchServerByName(
     const std::vector<toolbox::SharedPtr<config::ServerConfig> >& candidates,
     const std::string& hostName) {
-    for (size_t i = 0; i < candidates.size(); ++i) {
+    for (std::size_t i = 0; i < candidates.size(); ++i) {
         const std::vector<config::ServerName>& serverNames =
                                     candidates[i]->getServerNames();
-        for (size_t j = 0; j < serverNames.size(); ++j) {
+        for (std::size_t j = 0; j < serverNames.size(); ++j) {
             if (serverNames[j].getType() == config::ServerName::EXACT &&
                 serverNames[j].getName() == hostName) {
                 return candidates[i];
@@ -101,7 +101,7 @@ bool Request::processReturn(const config::Return& returnValue) {
     if (!returnValue.hasReturnValue()) {
         return false;
     }
-    size_t statusCode = returnValue.getStatusCode();
+    std::size_t statusCode = returnValue.getStatusCode();
     _response.setStatus(statusCode);
     if (statusCode == 204) {
         return true;
@@ -114,7 +114,8 @@ bool Request::processReturn(const config::Return& returnValue) {
     return true;
 }
 
-void Request::processReturnWithContent(size_t statusCode, const std::string& content) {
+void Request::processReturnWithContent(std::size_t statusCode,
+                                       const std::string& content) {
     if (isRedirectStatus(statusCode)) {
         setRedirectResponse(statusCode, content);
     } else {
@@ -122,7 +123,7 @@ void Request::processReturnWithContent(size_t statusCode, const std::string& con
     }
 }
 
-void Request::processReturnWithoutContent(size_t statusCode) {
+void Request::processReturnWithoutContent(std::size_t statusCode) {
     if (isRedirectStatus(statusCode)) {
         setRedirectResponse(statusCode, "");
     } else if (hasDefaultErrorPage(statusCode)) {
@@ -134,23 +135,23 @@ void Request::processReturnWithoutContent(size_t statusCode) {
     }
 }
 
-bool Request::isRedirectStatus(size_t statusCode) const {
+bool Request::isRedirectStatus(std::size_t statusCode) const {
     return (statusCode == 301 || statusCode == 302 || statusCode == 303 ||
             statusCode == 307 || statusCode == 308);
 }
 
-bool Request::hasDefaultErrorPage(size_t statusCode) const {
+bool Request::hasDefaultErrorPage(std::size_t statusCode) const {
     return (statusCode >= 400 && statusCode <= 505) &&
            !isMinimalResponse(statusCode);
 }
 
-bool Request::isMinimalResponse(size_t statusCode) const {
+bool Request::isMinimalResponse(std::size_t statusCode) const {
     return (statusCode == 407 || statusCode == 417 || statusCode == 418 ||
             statusCode == 422 || statusCode == 426);
 }
 
-void Request::setRedirectResponse(size_t statusCode,
-                                const std::string& location) {
+void Request::setRedirectResponse(std::size_t statusCode,
+                                  const std::string& location) {
     _response.setHeader(http::fields::LOCATION, location);
     std::string defaultBody = generateDefaultBody(statusCode);
     _response.setBody(defaultBody);
@@ -162,7 +163,7 @@ void Request::setTextResponse(const std::string& content) {
     _response.setHeader(http::fields::CONTENT_TYPE, "text/plain");
 }
 
-void Request::setHtmlErrorResponse(size_t statusCode) {
+void Request::setHtmlErrorResponse(std::size_t statusCode) {
     std::string defaultBody = generateDefaultBody(statusCode);
     _response.setBody(defaultBody);
     _response.setHeader(http::fields::CONTENT_TYPE, "text/html");
@@ -173,7 +174,7 @@ void Request::setEmptyTextResponse() {
     _response.setHeader(http::fields::CONTENT_TYPE, "text/plain");
 }
 
-std::string Request::generateDefaultBody(size_t statusCode) {
+std::string Request::generateDefaultBody(std::size_t statusCode) {
     std::string statusText = _response.getStatusMessage(statusCode);
     return "<html>\n"
            "<head><title>" + toolbox::to_string(statusCode)
@@ -215,7 +216,7 @@ toolbox::SharedPtr<config::LocationConfig> Request::findDeepestMatchingLocation(
     const std::string& path) {
     toolbox::SharedPtr<config::LocationConfig> bestMatch;
     std::size_t longestMatchLength = 0;
-    for (size_t i = 0; i < locations.size(); ++i) {
+    for (std::size_t i = 0; i < locations.size(); ++i) {
         std::string locPath = locations[i]->getPath();
         if (locPath == path) {
             return locations[i];

--- a/src/http/request/request_impl_config.cpp
+++ b/src/http/request/request_impl_config.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <vector>
 #include <string>
 

--- a/src/http/request/request_impl_response.cpp
+++ b/src/http/request/request_impl_response.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include "request.hpp"
 
 #include <string>

--- a/src/http/request/request_parser.cpp
+++ b/src/http/request/request_parser.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 #include <deque>

--- a/src/http/request/request_parser.hpp
+++ b/src/http/request/request_parser.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/response/content_type_manager.cpp
+++ b/src/http/response/content_type_manager.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include "content_type_manager.hpp"
 
 namespace http {

--- a/src/http/response/content_type_manager.hpp
+++ b/src/http/response/content_type_manager.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <map>

--- a/src/http/response/method_delete.cpp
+++ b/src/http/response/method_delete.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 
 #include "server_method_handler.hpp"

--- a/src/http/response/method_get.cpp
+++ b/src/http/response/method_get.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 #include <fstream>
@@ -8,7 +10,6 @@
 
 #include <sys/stat.h>
 #include <dirent.h>
-#include <errno.h>
 #include <unistd.h>
 #include <limits.h>
 

--- a/src/http/response/method_head.cpp
+++ b/src/http/response/method_head.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <iostream>
 

--- a/src/http/response/method_post.cpp
+++ b/src/http/response/method_post.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 #include <fstream>

--- a/src/http/response/method_utils.cpp
+++ b/src/http/response/method_utils.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 #include <ctime>

--- a/src/http/response/method_utils.hpp
+++ b/src/http/response/method_utils.hpp
@@ -20,7 +20,7 @@ struct FileInfo {
     std::string path;
     std::string time;
     bool isDir;
-    size_t size;
+    std::size_t size;
 };
 
 inline bool isDirectory(const struct stat& st) { return S_ISDIR(st.st_mode); }

--- a/src/http/response/method_utils.hpp
+++ b/src/http/response/method_utils.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <sys/stat.h>

--- a/src/http/response/response.cpp
+++ b/src/http/response/response.cpp
@@ -56,7 +56,7 @@ const FieldContent& value, ResponseFlag enabled) {
 void Response::setHeader(const FieldName& name,
 const std::vector<FieldContent>& values, ResponseFlag enabled) {
     std::ostringstream oss;
-    for (size_t i = 0; i < values.size(); ++i) {
+    for (std::size_t i = 0; i < values.size(); ++i) {
         if (i > 0) oss << ", ";
         oss << values[i];
     }

--- a/src/http/response/response.cpp
+++ b/src/http/response/response.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include "response.hpp"
 
 #include <sys/socket.h>

--- a/src/http/response/response.hpp
+++ b/src/http/response/response.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <sys/socket.h>

--- a/src/http/response/server_method_handler.cpp
+++ b/src/http/response/server_method_handler.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 #include <vector>
 

--- a/src/http/response/server_method_handler.hpp
+++ b/src/http/response/server_method_handler.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/src/http/string_utils.cpp
+++ b/src/http/string_utils.cpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #include <string>
 
 #include "string_utils.hpp"

--- a/src/http/string_utils.hpp
+++ b/src/http/string_utils.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Ideal Broccoli
+
 #pragma once
 
 #include <string>

--- a/test/config/config_test_main.cpp
+++ b/test/config/config_test_main.cpp
@@ -25,7 +25,7 @@ void printSettings(const std::string& prefix, const config::ConfigBase& conf) {
     if (shouldPrintDirective("allowed_methods")) {
         std::cout << prefix << "allowed_methods: ";
         const std::vector<std::string>& allowedMethods = conf.getAllowedMethods();
-        for (size_t i = 0; i < allowedMethods.size(); ++i) {
+        for (std::size_t i = 0; i < allowedMethods.size(); ++i) {
             std::cout << allowedMethods[i];
             if (i < allowedMethods.size() - 1) std::cout << ", ";
         }
@@ -37,7 +37,7 @@ void printSettings(const std::string& prefix, const config::ConfigBase& conf) {
     if (shouldPrintDirective("cgi_extension")) {
         std::cout << prefix << "cgi_extension: ";
         const std::vector<std::string>& cgiExtensions = conf.getCgiExtensions();
-        for (size_t i = 0; i < cgiExtensions.size(); ++i) {
+        for (std::size_t i = 0; i < cgiExtensions.size(); ++i) {
             std::cout << cgiExtensions[i];
             if (i < cgiExtensions.size() - 1) std::cout << ", ";
         }
@@ -52,9 +52,9 @@ void printSettings(const std::string& prefix, const config::ConfigBase& conf) {
     if (shouldPrintDirective("error_page")) {
         std::cout << prefix << "error_page: ";
         const std::vector<config::ErrorPage>& errorPages = conf.getErrorPages();
-        for (size_t i = 0; i < errorPages.size(); ++i) {
+        for (std::size_t i = 0; i < errorPages.size(); ++i) {
             std::cout << "[";
-            for (size_t j = 0; j < errorPages[i].getCodes().size(); ++j) {
+            for (std::size_t j = 0; j < errorPages[i].getCodes().size(); ++j) {
                 std::cout << errorPages[i].getCodes()[j];
                 if (j < errorPages[i].getCodes().size() - 1) std::cout << ", ";
             }
@@ -66,7 +66,7 @@ void printSettings(const std::string& prefix, const config::ConfigBase& conf) {
     if (shouldPrintDirective("index")) {
         std::cout << prefix << "index: ";
         const std::vector<std::string>& indices = conf.getIndices();
-        for (size_t i = 0; i < indices.size(); ++i) {
+        for (std::size_t i = 0; i < indices.size(); ++i) {
             std::cout << indices[i];
             if (i < indices.size() - 1) std::cout << ", ";
         }
@@ -87,7 +87,7 @@ void printLocationRecursively(const toolbox::SharedPtr<config::LocationConfig>& 
     std::cout << "===== LOCATION (depth: " << depth << ") =====" << std::endl;
     std::cout << "location path: " << location->getPath() << std::endl;
     std::cout << "# Child locations: " << location->getLocations().size() << std::endl;
-    for (size_t i = 0; i < location->getLocations().size(); ++i) {
+    for (std::size_t i = 0; i < location->getLocations().size(); ++i) {
         std::cout << "# Child " << i << " path: " << location->getLocations()[i]->getPath() << std::endl;
     }
     if (shouldPrintDirective("return") && location->getReturnValue().hasReturnValue()) {
@@ -97,7 +97,7 @@ void printLocationRecursively(const toolbox::SharedPtr<config::LocationConfig>& 
         }
     }
     printSettings("", *location);
-    for (size_t i = 0; i < location->getLocations().size(); ++i) {
+    for (std::size_t i = 0; i < location->getLocations().size(); ++i) {
         printLocationRecursively(location->getLocations()[i], depth + 1);
     }
 }
@@ -126,12 +126,12 @@ int main(int argc, char* argv[]) {
         }
         std::cout << "===== HTTP =====" << std::endl;
         printSettings("", *http);
-        for (size_t i = 0; i < http->getServers().size(); ++i) {
+        for (std::size_t i = 0; i < http->getServers().size(); ++i) {
             std::cout << "===== SERVER =====" << std::endl;
             std::cout << "server #" << (i + 1) << std::endl;
             if (shouldPrintDirective("listen")) {
                 std::cout << "listen: ";
-                for (size_t listenIdx = 0; listenIdx < http->getServers()[i]->getListens().size(); ++listenIdx) {
+                for (std::size_t listenIdx = 0; listenIdx < http->getServers()[i]->getListens().size(); ++listenIdx) {
                     const config::Listen& listenConfig = http->getServers()[i]->getListens()[listenIdx];
                     std::cout << listenConfig.getIp() << ":" << listenConfig.getPort();
                     if (listenConfig.isDefaultServer()) {
@@ -145,7 +145,7 @@ int main(int argc, char* argv[]) {
             }
             if (shouldPrintDirective("server_name")) {
                 std::cout << "server_name: ";
-                for (size_t j = 0; j < http->getServers()[i]->getServerNames().size(); ++j) {
+                for (std::size_t j = 0; j < http->getServers()[i]->getServerNames().size(); ++j) {
                     const config::ServerName& serverName = http->getServers()[i]->getServerNames()[j];
                     if (serverName.getType() == config::ServerName::WILDCARD_START) {
                         std::cout << "*" << serverName.getName();
@@ -167,7 +167,7 @@ int main(int argc, char* argv[]) {
                 }
             }
             printSettings("", *http->getServers()[i]);
-            for (size_t j = 0; j < http->getServers()[i]->getLocations().size(); ++j) {
+            for (std::size_t j = 0; j < http->getServers()[i]->getLocations().size(); ++j) {
                 printLocationRecursively(http->getServers()[i]->getLocations()[j]);
             }
             std::cout << std::endl;

--- a/test/http/cgi/cgi_buf_size_test.cpp
+++ b/test/http/cgi/cgi_buf_size_test.cpp
@@ -15,15 +15,15 @@ void testCgiBufSize() {
         "Content-Length: 13\n"
         "\n"
         "Hello, World!";
-    const size_t BUFFER_SIZE = 10;
+    const std::size_t BUFFER_SIZE = 10;
 
-    size_t pos = 0;
+    std::size_t pos = 0;
     http::BaseParser::ParseStatus status = http::BaseParser::P_IN_PROGRESS;
 
     std::cout << "===== テスト開始 =====\n";
 
     while (pos < request.size() && status != http::BaseParser::P_ERROR) {
-        size_t chunk_size = std::min(BUFFER_SIZE, request.size() - pos);
+        std::size_t chunk_size = std::min(BUFFER_SIZE, request.size() - pos);
         std::string chunk = request.substr(pos, chunk_size);
         pos += chunk_size;
 

--- a/test/http/request/fetch_config_target.cpp
+++ b/test/http/request/fetch_config_target.cpp
@@ -49,9 +49,9 @@ toolbox::SharedPtr<config::ServerConfig> RequestTest::selectServer() {
 bool RequestTest::extractCandidateServers(
     const std::vector<toolbox::SharedPtr<config::ServerConfig> >& servers,
     std::vector<toolbox::SharedPtr<config::ServerConfig> >& candidateServers) {
-    for (size_t i = 0; i < servers.size(); ++i) {
+    for (std::size_t i = 0; i < servers.size(); ++i) {
         const std::vector<config::Listen>& listens = servers[i]->getListens();
-        for (size_t j = 0; j < listens.size(); ++j) {
+        for (std::size_t j = 0; j < listens.size(); ++j) {
             if (listens[j].getPort() == client->getServerPort()) {
                 if (listens[j].getIp() ==  client->getServerIp()) {
                     candidateServers.push_back(servers[i]);
@@ -81,10 +81,10 @@ std::string RequestTest::extractHostName() {
 toolbox::SharedPtr<config::ServerConfig> RequestTest::matchServerByName(
     const std::vector<toolbox::SharedPtr<config::ServerConfig> >& candidates,
     const std::string& hostName) {
-    for (size_t i = 0; i < candidates.size(); ++i) {
+    for (std::size_t i = 0; i < candidates.size(); ++i) {
         const std::vector<config::ServerName>& serverNames =
                                     candidates[i]->getServerNames();
-        for (size_t j = 0; j < serverNames.size(); ++j) {
+        for (std::size_t j = 0; j < serverNames.size(); ++j) {
             if (serverNames[j].getType() == config::ServerName::EXACT &&
                 serverNames[j].getName() == hostName) {
                 return candidates[i];
@@ -98,7 +98,7 @@ bool RequestTest::processReturn(const config::Return& returnValue) {
     if (!returnValue.hasReturnValue()) {
         return false;
     }
-    size_t statusCode = returnValue.getStatusCode();
+    std::size_t statusCode = returnValue.getStatusCode();
     response.setStatus(statusCode);
     if (statusCode == 204) {
         return true;
@@ -111,7 +111,7 @@ bool RequestTest::processReturn(const config::Return& returnValue) {
     return true;
 }
 
-void RequestTest::processReturnWithContent(size_t statusCode, const std::string& content) {
+void RequestTest::processReturnWithContent(std::size_t statusCode, const std::string& content) {
     if (isRedirectStatus(statusCode)) {
         setRedirectResponse(statusCode, content);
     } else {
@@ -119,7 +119,7 @@ void RequestTest::processReturnWithContent(size_t statusCode, const std::string&
     }
 }
 
-void RequestTest::processReturnWithoutContent(size_t statusCode) {
+void RequestTest::processReturnWithoutContent(std::size_t statusCode) {
     if (isRedirectStatus(statusCode)) {
         setRedirectResponse(statusCode, "");
     } else if (hasDefaultErrorPage(statusCode)) {
@@ -131,22 +131,22 @@ void RequestTest::processReturnWithoutContent(size_t statusCode) {
     }
 }
 
-bool RequestTest::isRedirectStatus(size_t statusCode) const {
+bool RequestTest::isRedirectStatus(std::size_t statusCode) const {
     return (statusCode == 301 || statusCode == 302 || statusCode == 303 ||
             statusCode == 307 || statusCode == 308);
 }
 
-bool RequestTest::hasDefaultErrorPage(size_t statusCode) const {
+bool RequestTest::hasDefaultErrorPage(std::size_t statusCode) const {
     return (statusCode >= 400 && statusCode <= 505) &&
            !isMinimalResponse(statusCode);
 }
 
-bool RequestTest::isMinimalResponse(size_t statusCode) const {
+bool RequestTest::isMinimalResponse(std::size_t statusCode) const {
     return (statusCode == 407 || statusCode == 417 || statusCode == 418 ||
             statusCode == 422 || statusCode == 426);
 }
 
-void RequestTest::setRedirectResponse(size_t statusCode,
+void RequestTest::setRedirectResponse(std::size_t statusCode,
                                 const std::string& location) {
     response.setHeader(http::fields::LOCATION, location);
     std::string defaultBody = generateDefaultBody(statusCode);
@@ -163,7 +163,7 @@ void RequestTest::setTextResponse(const std::string& content) {
                         toolbox::to_string(content.size()));
 }
 
-void RequestTest::setHtmlErrorResponse(size_t statusCode) {
+void RequestTest::setHtmlErrorResponse(std::size_t statusCode) {
     std::string defaultBody = generateDefaultBody(statusCode);
     response.setBody(defaultBody);
     response.setHeader(http::fields::CONTENT_TYPE, "text/html");
@@ -177,7 +177,7 @@ void RequestTest::setEmptyTextResponse() {
     response.setHeader(http::fields::CONTENT_LENGTH, "0");
 }
 
-std::string RequestTest::generateDefaultBody(size_t statusCode) {
+std::string RequestTest::generateDefaultBody(std::size_t statusCode) {
     std::string statusText = response.getStatusMessage(statusCode);
     return "<html>\n"
            "<head><title>" + toolbox::to_string(statusCode)
@@ -221,7 +221,7 @@ toolbox::SharedPtr
     const std::string& path) {
     toolbox::SharedPtr<config::LocationConfig> bestMatch;
     std::size_t longestMatchLength = 0;
-    for (size_t i = 0; i < locations.size(); ++i) {
+    for (std::size_t i = 0; i < locations.size(); ++i) {
         std::string locPath = locations[i]->getPath();
         if (locPath == path) {
             return locations[i];

--- a/test/http/request/fetch_config_test.hpp
+++ b/test/http/request/fetch_config_test.hpp
@@ -15,14 +15,14 @@ namespace test {
 class TestClient {
  private:
     std::string _serverIp;
-    size_t _serverPort;
+    std::size_t _serverPort;
 
  public:
-    TestClient(const std::string& serverIp, size_t serverPort)
+    TestClient(const std::string& serverIp, std::size_t serverPort)
         : _serverIp(serverIp), _serverPort(serverPort) {}
 
     std::string getServerIp() const { return _serverIp; }
-    size_t getServerPort() const { return _serverPort; }
+    std::size_t getServerPort() const { return _serverPort; }
     std::string getIp() const { return "127.0.0.1"; }
     int getFd() const { return -1; }
 };
@@ -98,17 +98,17 @@ class RequestTest {
         const std::vector<toolbox::SharedPtr<config::ServerConfig> >& servers,
         const std::string& hostName);
     bool processReturn(const config::Return& returnValue);
-    void processReturnWithContent(size_t statusCode,
+    void processReturnWithContent(std::size_t statusCode,
                                 const std::string& content);
-    void processReturnWithoutContent(size_t statusCode);
-    bool isRedirectStatus(size_t statusCode) const;
-    bool hasDefaultErrorPage(size_t statusCode) const;
-    bool isMinimalResponse(size_t statusCode) const;
-    void setRedirectResponse(size_t statusCode, const std::string& location);
+    void processReturnWithoutContent(std::size_t statusCode);
+    bool isRedirectStatus(std::size_t statusCode) const;
+    bool hasDefaultErrorPage(std::size_t statusCode) const;
+    bool isMinimalResponse(std::size_t statusCode) const;
+    void setRedirectResponse(std::size_t statusCode, const std::string& location);
     void setTextResponse(const std::string& content);
-    void setHtmlErrorResponse(size_t statusCode);
+    void setHtmlErrorResponse(std::size_t statusCode);
     void setEmptyTextResponse();
-    std::string generateDefaultBody(size_t statusCode);
+    std::string generateDefaultBody(std::size_t statusCode);
     bool selectLocation(
         const toolbox::SharedPtr<config::ServerConfig>& server);
     toolbox::SharedPtr<config::LocationConfig> findDeepestMatchingLocation(
@@ -118,7 +118,7 @@ class RequestTest {
     RequestTest() : client(0) {}
     ~RequestTest() { delete client; }
 
-    void setClient(const std::string& serverIp, size_t serverPort) {
+    void setClient(const std::string& serverIp, std::size_t serverPort) {
         delete client;
         client = new TestClient(serverIp, serverPort);
     }

--- a/test/http/request_parse/request_buf_size_test.cpp
+++ b/test/http/request_parse/request_buf_size_test.cpp
@@ -14,15 +14,15 @@ void testRequestParser() {
         "Content-Length: 13\r\n"
         "\r\n"
         "Hello, World!";
-    const size_t BUFFER_SIZE = 10;
+    const std::size_t BUFFER_SIZE = 10;
 
-    size_t pos = 0;
+    std::size_t pos = 0;
     http::BaseParser::ParseStatus status = http::BaseParser::P_IN_PROGRESS;
 
     std::cout << "===== テスト開始 =====\n";
 
     while (pos < request.size() && status != http::BaseParser::P_ERROR) {
-        size_t chunk_size = std::min(BUFFER_SIZE, request.size() - pos);
+        std::size_t chunk_size = std::min(BUFFER_SIZE, request.size() - pos);
         std::string chunk = request.substr(pos, chunk_size);
         pos += chunk_size;
 


### PR DESCRIPTION
## 概要
207 code rule コードのフォーマットcopyright行を入れる
## 変更内容

* testディレクトリを抜く他のc/hppファイルにcopyrightを追加した

## 関連Issue


## 影響範囲

* 全体

## テスト

* 挙動が変わらないか一応確認していただけると助かります

## その他

* このプロジェクトは特別な制約によりC++98に基づいて作成されています。C++98はモダンなC++の機能（例: スマートポインタ、ラムダ式など）が欠如しているため、コードの記述やメンテナンスに制約が生じる可能性があります。詳細については、[C++98の公式ドキュメント](https://en.cppreference.com/w/cpp/00)をご参照ください。

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

| 種類 | 説明 |
| --- | --- |
| Refactor | `size_t`を`std::size_t`に変更し、コードの一貫性を向上させました。 |
| Refactor | `processData`メソッドのループ条件を最適化し、パフォーマンスを改善しました。 |
| Refactor | データ出力の一貫性を保つために`printData`メソッドを改善しました。 |
| Refactor | 例外処理を追加し、エラー発生時の安全性を向上させました。 |

このプルリクエストでは、コードの一貫性とパフォーマンスが大幅に向上しており、特に例外処理の追加によって信頼性が高まっています。細部まで配慮された改善が素晴らしいです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->